### PR TITLE
Use the class loader for the RavenFactory class

### DIFF
--- a/raven/src/main/java/net/kencochrane/raven/RavenFactory.java
+++ b/raven/src/main/java/net/kencochrane/raven/RavenFactory.java
@@ -15,7 +15,7 @@ import java.util.Set;
  * The factories register themselves through the {@link ServiceLoader} system.
  */
 public abstract class RavenFactory {
-    private static final ServiceLoader<RavenFactory> AUTO_REGISTERED_FACTORIES = ServiceLoader.load(RavenFactory.class);
+    private static final ServiceLoader<RavenFactory> AUTO_REGISTERED_FACTORIES = ServiceLoader.load(RavenFactory.class, RavenFactory.class.getClassLoader());
     private static final Set<RavenFactory> MANUALLY_REGISTERED_FACTORIES = new HashSet<>();
     private static final Logger logger = LoggerFactory.getLogger(RavenFactory.class);
 

--- a/raven/src/main/java/net/kencochrane/raven/RavenFactory.java
+++ b/raven/src/main/java/net/kencochrane/raven/RavenFactory.java
@@ -15,7 +15,8 @@ import java.util.Set;
  * The factories register themselves through the {@link ServiceLoader} system.
  */
 public abstract class RavenFactory {
-    private static final ServiceLoader<RavenFactory> AUTO_REGISTERED_FACTORIES = ServiceLoader.load(RavenFactory.class, RavenFactory.class.getClassLoader());
+    private static final ServiceLoader<RavenFactory> AUTO_REGISTERED_FACTORIES =
+        ServiceLoader.load(RavenFactory.class, RavenFactory.class.getClassLoader());
     private static final Set<RavenFactory> MANUALLY_REGISTERED_FACTORIES = new HashSet<>();
     private static final Logger logger = LoggerFactory.getLogger(RavenFactory.class);
 


### PR DESCRIPTION
Use the class loader for the factory class so that we use the class loader from which we are loading the factory. This avoids issues in containers when you have a copy of raven in the parent class loader, as well as the war. Using the ServiceLoader without the class loader of the factory causes the classes from the parent to be loaded instead of the war. This in-turn causes class cast and subtype errors.