### PR TITLE
allow to use custom EventBuilder

### DIFF
--- a/raven-logback/src/main/java/net/kencochrane/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/net/kencochrane/raven/logback/SentryAppender.java
@@ -161,7 +161,7 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      * @return Event containing details provided by the logging system.
      */
     protected Event buildEvent(ILoggingEvent iLoggingEvent) {
-        EventBuilder eventBuilder = new EventBuilder()
+        EventBuilder eventBuilder = getEventBuilder()
                 .withTimestamp(new Date(iLoggingEvent.getTimeStamp()))
                 .withMessage(iLoggingEvent.getFormattedMessage())
                 .withLogger(iLoggingEvent.getLoggerName())
@@ -205,6 +205,10 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
 
         raven.runBuilderHelpers(eventBuilder);
         return eventBuilder.build();
+    }
+
+    private EventBuilder getEventBuilder() {
+        return new EventBuilder();
     }
 
     private Deque<SentryException> extractExceptionQueue(ILoggingEvent iLoggingEvent) {


### PR DESCRIPTION
We are running on App Engine and have a problem with the default EventBuilder implementation. It is polluting our logs:

```
EventBuilder.HostnameCache updateCache: Localhost hostname lookup failed, keeping the value 'unavailable'
java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "modifyThreadGroup")
	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:375)
	at java.security.AccessController.checkPermission(AccessController.java:565)
	at java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
	at com.google.apphosting.runtime.security.CustomSecurityManager.checkPermission(CustomSecurityManager.java:56)
	at com.google.apphosting.runtime.security.CustomSecurityManager.checkAccess(CustomSecurityManager.java:131)
	at java.lang.ThreadGroup.checkAccess(ThreadGroup.java:315)
	at java.lang.Thread.init(Thread.java:378)
	at java.lang.Thread.<init>(Thread.java:448)
	at net.kencochrane.raven.event.EventBuilder$HostnameCache.updateCache(EventBuilder.java:354)
	at net.kencochrane.raven.event.EventBuilder$HostnameCache.getHostname(EventBuilder.java:342)
	at net.kencochrane.raven.event.EventBuilder.autoSetMissingValues(EventBuilder.java:88)
	at net.kencochrane.raven.event.EventBuilder.build(EventBuilder.java:286)
	at net.kencochrane.raven.logback.SentryAppender.buildEvent(SentryAppender.java:199)```

So we would like to use a custom EventBuilder that ignores the hostname lookup. This change would allow us to do just that.