### PR TITLE
Add option to clean lambda frames from stack traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# Maven
 target/
+
+# IntelliJ
+.idea/*
+*.iml

--- a/raven/src/main/java/net/kencochrane/raven/DefaultRavenFactory.java
+++ b/raven/src/main/java/net/kencochrane/raven/DefaultRavenFactory.java
@@ -58,6 +58,10 @@ public class DefaultRavenFactory extends RavenFactory {
      * Option to hide common stackframes with enclosing exceptions.
      */
     public static final String HIDE_COMMON_FRAMES_OPTION = "raven.stacktrace.hidecommon";
+    /**
+     * Option to clean auto-generated Java 8 lambda class and method names from stacktrace frames.
+     */
+    public static final String CLEAN_LAMBDA_FRAMES_OPTION = "raven.stacktrace.cleanlambda";
     private static final Logger logger = LoggerFactory.getLogger(DefaultRavenFactory.class);
     private static final String FALSE = Boolean.FALSE.toString();
 
@@ -193,6 +197,9 @@ public class DefaultRavenFactory extends RavenFactory {
         // Enable common frames hiding unless its value is 'false'.
         stackTraceBinding.setRemoveCommonFramesWithEnclosing(
                 !FALSE.equalsIgnoreCase(dsn.getOptions().get(HIDE_COMMON_FRAMES_OPTION)));
+        // Enable cleaning lambda frames unless its value is 'false'.
+        stackTraceBinding.setCleanLambdaFrames(
+                !FALSE.equalsIgnoreCase(dsn.getOptions().get(CLEAN_LAMBDA_FRAMES_OPTION)));
         stackTraceBinding.setNotInAppFrames(getNotInAppFrames());
 
         marshaller.addInterfaceBinding(StackTraceInterface.class, stackTraceBinding);

--- a/raven/src/test/java/net/kencochrane/raven/marshaller/json/StackTraceInterfaceBindingTest.java
+++ b/raven/src/test/java/net/kencochrane/raven/marshaller/json/StackTraceInterfaceBindingTest.java
@@ -66,4 +66,30 @@ public class StackTraceInterfaceBindingTest {
 
         assertThat(jsonGeneratorParser.value(), is(jsonResource("/net/kencochrane/raven/marshaller/json/StackTrace3.json")));
     }
+
+    @Test
+    public void testFramesCleanLambdaFrames() throws Exception {
+        testFramesCleanLambdaFrames(true, "/net/kencochrane/raven/marshaller/json/StackTrace4.json");
+    }
+
+    @Test
+    public void testFramesCleanLambdaFramesDisabled() throws Exception {
+        testFramesCleanLambdaFrames(false, "/net/kencochrane/raven/marshaller/json/StackTrace5.json");
+    }
+
+    private void testFramesCleanLambdaFrames(boolean cleanLambdaFrames, String jsonResource) throws Exception {
+        final JsonGeneratorParser jsonGeneratorParser = newJsonGenerator();
+        final String methodName = "lambda$work$1";
+        final String className = "com.company.module.$$Lambda$30/2081171245";
+        final StackTraceElement stackTraceElement = new StackTraceElement(className, methodName, null, 0);
+        new NonStrictExpectations() {{
+            mockStackTraceInterface.getStackTrace();
+            result = new StackTraceElement[]{stackTraceElement};
+        }};
+        interfaceBinding.setCleanLambdaFrames(cleanLambdaFrames);
+
+        interfaceBinding.writeInterface(jsonGeneratorParser.generator(), mockStackTraceInterface);
+
+        assertThat(jsonGeneratorParser.value(), is(jsonResource(jsonResource)));
+    }
 }

--- a/raven/src/test/resources/net/kencochrane/raven/marshaller/json/StackTrace4.json
+++ b/raven/src/test/resources/net/kencochrane/raven/marshaller/json/StackTrace4.json
@@ -1,0 +1,8 @@
+{"frames": [
+    {
+        "module": "com.company.module.$$Lambda$",
+        "in_app": true,
+        "function": "lambda$work$",
+        "lineno": 0
+    }
+]}

--- a/raven/src/test/resources/net/kencochrane/raven/marshaller/json/StackTrace5.json
+++ b/raven/src/test/resources/net/kencochrane/raven/marshaller/json/StackTrace5.json
@@ -1,0 +1,8 @@
+{"frames": [
+    {
+        "module": "com.company.module.$$Lambda$30/2081171245",
+        "in_app": true,
+        "function": "lambda$work$1",
+        "lineno": 0
+    }
+]}


### PR DESCRIPTION
This adds a DSN option `raven.stacktrace.cleanlambda` (on by default) to clean auto-generated java 8 lambda class and method names from stack trace frames.

When using lambdas, java will auto-generate class names in the form `$$Lambda$30/2081171245` and method names in the form `lambda$work$1`.

The numbers at the end of those class + method names change between calls, which causes the stack trace checksum to differ between calls, which causes sentry server grouping to fail even though everything is exactly the same from a users perspective.

With this PR, the resulting class + method names that get sent to the sentry server will be `$$Lambda$` and `lambda$work$`.
