### PR TITLE
replacing mappedTags references with extraTags in ReadME

### DIFF
--- a/raven-logback/README.md
+++ b/raven-logback/README.md
@@ -51,12 +51,12 @@ add a tag `logback-Marker`.
 allows to add extra information to the event.
 
 ### Mapped Tags
-By default all MDC parameters are sent under the Additional Data Tab. By specify the mappedTags parameter in your
+By default all MDC parameters are sent under the Additional Data Tab. By specify the extraTags parameter in your
 configuration file. You can specify MDC keys to send as tags instead of including them in Additional Data.
 This allows them to be filtered within Sentry.
 
 ```xml
-<mappedTags>User,OS</mappedTags>
+<extraTags>User,OS</extraTags>
 ```
 ```java
     void logWithExtras() {
@@ -64,7 +64,7 @@ This allows them to be filtered within Sentry.
         MDC.put("User", "test user");
         MDC.put("OS", "Linux");
 
-        // This adds a message with extras and MDC keys declared in mappedTags as tags to Sentry
+        // This adds a message with extras and MDC keys declared in extraTags as tags to Sentry
         logger.info("This is a test");
     }
 ```


### PR DESCRIPTION
The logback documentation refers to `mappedTags` rather than the implemented `extraTags`. This fixes the documentation to reflect the code in use.