### PR TITLE
Engage checkstyle check during packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,7 @@
                             <configuration>
                                 <skip>${skipTests}</skip>
                             </configuration>
+                            <phase>package</phase>
                             <goals>
                                 <goal>check</goal>
                             </goals>


### PR DESCRIPTION
Otherwise, no one will know to run `checkstyle:check` until the Travis CI build bombs