### PR TITLE
change mappedTags -> extraTags.

### DIFF
--- a/raven-log4j/README.md
+++ b/raven-log4j/README.md
@@ -93,13 +93,13 @@ public class MyClass {
 }
 ```
 
-### Mapped Tags
-By default all MDC parameters are sent under the Additional Data Tab. By specify the mappedTags parameter in your
+### Extra Tags
+By default all MDC parameters are sent under the Additional Data Tab. By specify the extraTags parameter in your
 configuration file. You can specify MDC keys to send as tags instead of including them in Additional Data.
 This allows them to be filtered within Sentry.
 
 ```properties
-log4j.appender.SentryAppender.mappedTags=User,OS
+log4j.appender.SentryAppender.extraTags=User,OS
 ```
 ```java
     void logWithExtras() {


### PR DESCRIPTION
https://github.com/getsentry/raven-java/blob/master/raven-log4j/src/main/java/net/kencochrane/raven/log4j/SentryAppender.java 

mappedTags is not used in SentryAppender.

Instead of "mappedTags", user should use "extraTags".