### PR TITLE
minimum event level filter for logback

### DIFF
--- a/raven-logback/README.md
+++ b/raven-logback/README.md
@@ -38,6 +38,8 @@ In the `logback.xml` file set:
         <!--<ravenFactory>net.kencochrane.raven.DefaultRavenFactory</ravenFactory>-->
         <!-- Optional, allows setting app release information -->
         <!-- <release>1.0.0</release>
+        <!-- Optional, events with level bellow minLevel won't be sent, defaults to WARN -->
+        <!-- <minLevel>ERROR</minLevel>
     </appender>
     <root level="warn">
         <appender-ref ref="Sentry"/>

--- a/raven-logback/src/main/java/net/kencochrane/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/net/kencochrane/raven/logback/SentryAppender.java
@@ -58,6 +58,10 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      */
     protected String release;
     /**
+     * If set, only events with level = minLevel and up will be recorded.
+     */
+    protected Level minLevel = Level.WARN;
+    /**
      * Additional tags to be sent to sentry.
      * <p>
      * Might be empty in which case no tags are sent.
@@ -134,6 +138,9 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         try {
             if (raven == null)
                 initRaven();
+
+            if (minLevel != null && !iLoggingEvent.getLevel().isGreaterOrEqual(minLevel))
+                return;
 
             Event event = buildEvent(iLoggingEvent);
             raven.sendEvent(event);
@@ -292,6 +299,11 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
     public void setRelease(String release) {
         this.release = release;
     }
+
+    public void setMinLevel(String minLevel) {
+        this.minLevel = Level.toLevel(minLevel, Level.WARN);
+    }
+
     /**
      * Set the tags that should be sent along with the events.
      *

--- a/raven-logback/src/test/java/net/kencochrane/raven/logback/SentryAppenderEventBuildingTest.java
+++ b/raven-logback/src/test/java/net/kencochrane/raven/logback/SentryAppenderEventBuildingTest.java
@@ -35,6 +35,7 @@ public class SentryAppenderEventBuildingTest {
     @Injectable
     private Context mockContext = null;
     private String mockExtraTag = "60f42409-c029-447d-816a-fb2722913c93";
+    private String mockMinLevel = "ALL";
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -42,6 +43,7 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender = new SentryAppender(mockRaven);
         sentryAppender.setContext(mockContext);
         sentryAppender.setExtraTags(mockExtraTag);
+        sentryAppender.setMinLevel(mockMinLevel);
 
         new NonStrictExpectations() {{
             final BasicStatusManager statusManager = new BasicStatusManager();

--- a/raven-logback/src/test/java/net/kencochrane/raven/logback/SentryAppenderEventLevelFilterTest.java
+++ b/raven-logback/src/test/java/net/kencochrane/raven/logback/SentryAppenderEventLevelFilterTest.java
@@ -1,0 +1,77 @@
+package net.kencochrane.raven.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.core.Context;
+import mockit.Injectable;
+import mockit.Tested;
+import mockit.Verifications;
+import net.kencochrane.raven.Raven;
+import net.kencochrane.raven.event.Event;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Felipe G Almeida
+ */
+public class SentryAppenderEventLevelFilterTest {
+    @Tested
+    private SentryAppender sentryAppender = null;
+    @Injectable
+    private Raven mockRaven = null;
+    @Injectable
+    private Context mockContext = null;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        new MockUpStatusPrinter();
+        sentryAppender = new SentryAppender(mockRaven);
+        sentryAppender.setContext(mockContext);
+    }
+
+    @DataProvider(name = "levels")
+    private Object[][] levelConversions() {
+        return new Object[][]{
+                {"ALL", 5},
+                {"TRACE", 5},
+                {"DEBUG", 4},
+                {"INFO", 3},
+                {"WARN", 2},
+                {"ERROR", 1},
+                {"error", 1},
+                {"xxx", 2},
+                {null, 2}};
+    }
+
+    @Test(dataProvider = "levels")
+    public void testLevelFilter(final String minLevel, final Integer expectedEvents) throws Exception {
+        sentryAppender.setMinLevel(minLevel);
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.TRACE, null, null, null).getMockInstance());
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.DEBUG, null, null, null).getMockInstance());
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.INFO, null, null, null).getMockInstance());
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.WARN, null, null, null).getMockInstance());
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.ERROR, null, null, null).getMockInstance());
+
+        new Verifications() {{
+            mockRaven.sendEvent((Event) any);
+            minTimes = expectedEvents;
+            maxTimes = expectedEvents;
+        }};
+    }
+
+    @Test
+    public void testDefaultLevelFilter() throws Exception {
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.TRACE, null, null, null).getMockInstance());
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.DEBUG, null, null, null).getMockInstance());
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.INFO, null, null, null).getMockInstance());
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.WARN, null, null, null).getMockInstance());
+        sentryAppender.append(new MockUpLoggingEvent(null, null, Level.ERROR, null, null, null).getMockInstance());
+
+        new Verifications() {{
+            mockRaven.sendEvent((Event) any);
+            minTimes = 2;
+            maxTimes = 2;
+        }};
+    }
+
+}

--- a/raven-logback/src/test/java/net/kencochrane/raven/logback/SentryAppenderFailuresTest.java
+++ b/raven-logback/src/test/java/net/kencochrane/raven/logback/SentryAppenderFailuresTest.java
@@ -43,6 +43,7 @@ public class SentryAppenderFailuresTest {
     public void testRavenFailureDoesNotPropagate() throws Exception {
         final SentryAppender sentryAppender = new SentryAppender(mockRaven);
         sentryAppender.setContext(mockContext);
+        sentryAppender.setMinLevel("ALL");
         new NonStrictExpectations() {{
             mockRaven.sendEvent((Event) any);
             result = new UnsupportedOperationException();

--- a/raven-logback/src/test/java/net/kencochrane/raven/logback/SentryAppenderIT.java
+++ b/raven-logback/src/test/java/net/kencochrane/raven/logback/SentryAppenderIT.java
@@ -25,9 +25,9 @@ public class SentryAppenderIT {
     }
 
     @Test
-    public void testInfoLog() throws Exception {
+    public void testWarnLog() throws Exception {
         assertThat(sentryStub.getEventCount(), is(0));
-        logger.info("This is a test");
+        logger.warn("This is a test");
         assertThat(sentryStub.getEventCount(), is(1));
     }
 


### PR DESCRIPTION
minimum event level filter for logback

warning: this breaks current behavior, since default filter level is WARN, events with lower levels will not be recorded anymore. See logback/README to change filter level.