### PR TITLE
Clarify Servlet 2.4 API dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Solutions exist for that problem:
  RavenFactory.registerFactory(new DefaultRavenFactory());
  ```
 
+## HTTP Request Context
+
+If the runtime environment utilizes Servlets, events that are created during
+the processing of an HTTP request will include additional contextual data about
+that active request, such as the URL, method, parameters, and other data. (This
+feature requires version 2.4 the Servlet API.)
+
 ## Connection and protocol
 It is possible to send events to Sentry over different protocols, depending
 on the security and performance requirements.

--- a/raven/src/main/java/net/kencochrane/raven/DefaultRavenFactory.java
+++ b/raven/src/main/java/net/kencochrane/raven/DefaultRavenFactory.java
@@ -66,10 +66,14 @@ public class DefaultRavenFactory extends RavenFactory {
         Raven raven = new Raven();
         raven.setConnection(createConnection(dsn));
         try {
-            Class.forName("javax.servlet.Servlet", false, this.getClass().getClassLoader());
+            // `ServletRequestListener` was added in the Servlet 2.4 API, and
+            // is used as part of the `HttpEventBuilderHelper`, see:
+            // https://tomcat.apache.org/tomcat-5.5-doc/servletapi/
+            Class.forName("javax.servlet.ServletRequestListener", false, this.getClass().getClassLoader());
             raven.addBuilderHelper(new HttpEventBuilderHelper());
         } catch (ClassNotFoundException e) {
-            logger.debug("It seems that the current environment doesn't provide access to servlets.");
+            logger.debug("The current environment doesn't provide access to servlets,"
+                         + "or provides an unsupported version.");
         }
         return raven;
     }


### PR DESCRIPTION
This improves:

- the check performed before instantiating the `HttpEventBuilderHelper` to ensure the correct Servlet version is available,
- documentation about the HTTP request context features.

Fixes GH-170.