### PR TITLE
Add setters for dsn and tags; Add printfStyle property

### DIFF
--- a/raven/src/main/java/net/kencochrane/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/net/kencochrane/raven/jul/SentryHandler.java
@@ -203,7 +203,11 @@ public class SentryHandler extends Handler {
             List<String> parameters = formatMessageParameters(record.getParameters());
             eventBuilder.withSentryInterface(new MessageInterface(message, parameters));
             if (printfStyle) {
-                message = String.format(message, record.getParameters());
+                try {
+                    message = String.format(message, record.getParameters());
+                } catch (MissingFormatArgumentException e) {
+                    // use unformatted message
+                }
             } else {
                 message = MessageFormat.format(message, record.getParameters());
             }

--- a/raven/src/main/java/net/kencochrane/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/net/kencochrane/raven/jul/SentryHandler.java
@@ -207,6 +207,7 @@ public class SentryHandler extends Handler {
                     message = String.format(message, record.getParameters());
                 } catch (MissingFormatArgumentException e) {
                     // use unformatted message
+                    message = record.getMessage();
                 }
             } else {
                 message = MessageFormat.format(message, record.getParameters());

--- a/raven/src/main/java/net/kencochrane/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/net/kencochrane/raven/jul/SentryHandler.java
@@ -37,6 +37,12 @@ public class SentryHandler extends Handler {
      */
     protected String dsn;
     /**
+     * If true, <code>String.format()</code> is used to render parameterized log
+     * messages instead of <code>MessageFormat.format()</code>; Defaults to
+     * false.
+     */
+    protected boolean printfStyle;
+    /**
      * Name of the {@link RavenFactory} being used.
      * <p>
      * Might be null in which case the factory should be defined automatically.
@@ -72,6 +78,10 @@ public class SentryHandler extends Handler {
 
     public void setDsn(String dsn) {
         this.dsn = dsn;
+    }
+
+    public void setPrintfStyle(boolean printfStyle) {
+        this.printfStyle = printfStyle;
     }
 
     /**
@@ -129,6 +139,7 @@ public class SentryHandler extends Handler {
         String className = SentryHandler.class.getName();
         dsn = manager.getProperty(className + ".dsn");
         ravenFactory = manager.getProperty(className + ".ravenFactory");
+        printfStyle = Boolean.valueOf(manager.getProperty(className + ".printfStyle"));
         String tagsProperty = manager.getProperty(className + ".tags");
         tags = parseTags(tagsProperty);
         String extraTagsProperty = manager.getProperty(className + ".extraTags");
@@ -191,7 +202,11 @@ public class SentryHandler extends Handler {
         if (record.getParameters() != null) {
             List<String> parameters = formatMessageParameters(record.getParameters());
             eventBuilder.withSentryInterface(new MessageInterface(message, parameters));
-            message = MessageFormat.format(message, record.getParameters());
+            if (printfStyle) {
+                message = String.format(message, record.getParameters());
+            } else {
+                message = MessageFormat.format(message, record.getParameters());
+            }
         }
         eventBuilder.withMessage(message);
 

--- a/raven/src/main/java/net/kencochrane/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/net/kencochrane/raven/jul/SentryHandler.java
@@ -70,6 +70,24 @@ public class SentryHandler extends Handler {
         this.raven = raven;
     }
 
+    public void setDsn(String dsn) {
+        this.dsn = dsn;
+    }
+
+    /**
+     * Populates the tags map by parsing the given tags property string.
+     * @param tagsProperty comma-delimited key-value pairs, e.g.
+     *                     "tag1:value1,tag2:value2".
+     */
+    public void setTags(String tagsProperty) {
+        this.tags = parseTags(tagsProperty);
+    }
+
+    private Map<String, String> parseTags(String tagsProperty) {
+        return tagsProperty == null ? Collections.<String, String>emptyMap()
+                : Splitter.on(",").withKeyValueSeparator(":").split(tagsProperty);
+    }
+
     /**
      * Transforms a {@link Level} into an {@link Event.Level}.
      *
@@ -112,8 +130,7 @@ public class SentryHandler extends Handler {
         dsn = manager.getProperty(className + ".dsn");
         ravenFactory = manager.getProperty(className + ".ravenFactory");
         String tagsProperty = manager.getProperty(className + ".tags");
-        if (tagsProperty != null)
-            tags = Splitter.on(",").withKeyValueSeparator(":").split(tagsProperty);
+        tags = parseTags(tagsProperty);
         String extraTagsProperty = manager.getProperty(className + ".extraTags");
         if (extraTagsProperty != null)
             extraTags = new HashSet<>(Arrays.asList(extraTagsProperty.split(",")));


### PR DESCRIPTION
Addresses #140 - Wildfly's [custom handler docs](http://wildscribe.github.io/Wildfly/8.2.0.Final/subsystem/logging/custom-handler/index.html) state that "all properties must be accessible via a setter method." Notably, I also had to incorporate #129 to get `SentryHandler` to work with Wildfly 8.2.0.Final.