### PR TITLE
Add printfStyle option to JUL integration.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Version 7.1.1
+-------------
+
+- Add printfStyle option to JUL integration. (thanks giilby)
+
 Version 7.1.0
 -------------
 


### PR DESCRIPTION
This is just the printf change from https://github.com/getsentry/raven-java/pull/174

By my reading/searching this is only necessary for JUL integration and WildFly, more modern logging facilities all use the `{}` style parametrized logging). Given that, I think the location of the format code seems reasonable.

Thoughts?