### PR TITLE
Override serverName

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 7.1.1
 - Updated Log4j2 documentation to refer to the Thread Context rather than the MDC. (thanks grobmeier)
 - Fix duplicate ShutdownHook warnings in ``raven-log4j2``.
 - Add way to override how remote addresses are resolved (RemoteAddressResolver interface). (thanks j-fernandes)
+- Add way to set ``serverName`` statically in configuration. (thanks mattbillenstein)
 
 Version 7.1.0
 -------------

--- a/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
@@ -55,6 +55,9 @@ public class SentryAppender extends AppenderSkeleton {
      * Might be null in which case no release is sent.
      */
     protected String release;
+
+    protected String serverName;
+
     /**
      * Additional tags to be sent to sentry.
      * <p>
@@ -171,6 +174,10 @@ public class SentryAppender extends AppenderSkeleton {
                 .withLogger(loggingEvent.getLoggerName())
                 .withLevel(formatLevel(loggingEvent.getLevel()))
                 .withExtra(THREAD_NAME, loggingEvent.getThreadName());
+
+        if (!Strings.isNullOrEmpty(serverName)) {
+            eventBuilder.withServerName(serverName.trim());
+        }
 
         if (!Strings.isNullOrEmpty(release)) {
             eventBuilder.withRelease(release.trim());

--- a/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
@@ -55,14 +55,12 @@ public class SentryAppender extends AppenderSkeleton {
      * Might be null in which case no release is sent.
      */
     protected String release;
-
     /**
-     * Server Name to be sent to sentry.
+     * Server name to be sent to sentry.
      * <p>
      * Might be null in which case the hostname is found via a reverse DNS lookup.
      */
     protected String serverName;
-
     /**
      * Additional tags to be sent to sentry.
      * <p>

--- a/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
@@ -56,6 +56,11 @@ public class SentryAppender extends AppenderSkeleton {
      */
     protected String release;
 
+    /**
+     * Server Name to be sent to sentry.
+     * <p>
+     * Might be null in which case the hostname is found via a reverse DNS lookup.
+     */
     protected String serverName;
 
     /**

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -70,6 +70,12 @@ public class SentryAppender extends AbstractAppender {
      */
     protected String release;
     /**
+     * Server name to be sent to sentry.
+     * <p>
+     * Might be null in which case the hostname is found via a reverse DNS lookup.
+     */
+    protected String serverName;
+    /**
      * Additional tags to be sent to sentry.
      * <p>
      * Might be empty in which case no tags are sent.
@@ -233,6 +239,10 @@ public class SentryAppender extends AbstractAppender {
                 .withLogger(event.getLoggerName())
                 .withLevel(formatLevel(event.getLevel()))
                 .withExtra(THREAD_NAME, event.getThreadName());
+
+        if (!Strings.isNullOrEmpty(serverName)) {
+            eventBuilder.withServerName(serverName.trim());
+        }
 
         if (!Strings.isNullOrEmpty(release)) {
             eventBuilder.withRelease(release.trim());

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -124,6 +124,7 @@ public class SentryAppender extends AbstractAppender {
      * @return The SentryAppender.
      */
     @PluginFactory
+    @SuppressWarnings("checkstyle:parameternumber")
     public static SentryAppender createAppender(@PluginAttribute("name") final String name,
                                                 @PluginAttribute("dsn") final String dsn,
                                                 @PluginAttribute("ravenFactory") final String ravenFactory,

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -127,6 +127,7 @@ public class SentryAppender extends AbstractAppender {
                                                 @PluginAttribute("dsn") final String dsn,
                                                 @PluginAttribute("ravenFactory") final String ravenFactory,
                                                 @PluginAttribute("release") final String release,
+                                                @PluginAttribute("serverName") final String serverName,
                                                 @PluginAttribute("tags") final String tags,
                                                 @PluginAttribute("extraTags") final String extraTags,
                                                 @PluginElement("filters") final Filter filter) {

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -141,6 +141,8 @@ public class SentryAppender extends AbstractAppender {
         sentryAppender.setDsn(dsn);
         if (release != null)
             sentryAppender.setRelease(release);
+        if (serverName != null)
+            sentryAppender.setServerName(serverName);
         if (tags != null)
             sentryAppender.setTags(tags);
         if (extraTags != null)
@@ -302,6 +304,10 @@ public class SentryAppender extends AbstractAppender {
 
     public void setRelease(String release) {
         this.release = release;
+    }
+
+    public void setServerName(String serverName) {
+        this.serverName = serverName;
     }
 
     /**

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -117,6 +117,7 @@ public class SentryAppender extends AbstractAppender {
      * @param dsn          Data Source Name to access the Sentry server.
      * @param ravenFactory Name of the factory to use to build the {@link Raven} instance.
      * @param release      Release to be sent to Sentry.
+     * @param serverName   serverName to be sent to Sentry.
      * @param tags         Tags to add to each event.
      * @param extraTags    Tags to search through the Thread Context Map.
      * @param filter       The filter, if any, to use.

--- a/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
@@ -59,6 +59,12 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      */
     protected String release;
     /**
+     * Server name to be sent to sentry.
+     * <p>
+     * Might be null in which case the hostname is found via a reverse DNS lookup.
+     */
+    protected String serverName;
+    /**
      * If set, only events with level = minLevel and up will be recorded.
      */
     protected Level minLevel = Level.WARN;
@@ -181,6 +187,10 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
                 .withLogger(iLoggingEvent.getLoggerName())
                 .withLevel(formatLevel(iLoggingEvent.getLevel()))
                 .withExtra(THREAD_NAME, iLoggingEvent.getThreadName());
+
+        if (!Strings.isNullOrEmpty(serverName)) {
+            eventBuilder.withServerName(serverName.trim());
+        }
 
         if (!Strings.isNullOrEmpty(release)) {
             eventBuilder.withRelease(release.trim());

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -154,6 +154,7 @@ public class SentryHandler extends Handler {
         printfStyle = Boolean.valueOf(manager.getProperty(className + ".printfStyle"));
         ravenFactory = manager.getProperty(className + ".ravenFactory");
         release = manager.getProperty(className + ".release");
+        serverName = manager.getProperty(className + ".serverName");
         String tagsProperty = manager.getProperty(className + ".tags");
         tags = parseTags(tagsProperty);
         String extraTagsProperty = manager.getProperty(className + ".extraTags");

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -56,6 +56,12 @@ public class SentryHandler extends Handler {
      */
     protected String release;
     /**
+     * Server name to be sent to sentry.
+     * <p>
+     * Might be null in which case the hostname is found via a reverse DNS lookup.
+     */
+    protected String serverName;
+    /**
      * Tags to add to every event.
      */
     protected Map<String, String> tags = Collections.emptyMap();
@@ -254,6 +260,10 @@ public class SentryHandler extends Handler {
 
         if (!Strings.isNullOrEmpty(release)) {
             eventBuilder.withRelease(release.trim());
+        }
+
+        if (!Strings.isNullOrEmpty(serverName)) {
+            eventBuilder.withServerName(serverName.trim());
         }
 
         raven.runBuilderHelpers(eventBuilder);

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -40,6 +40,7 @@
         <property name="onCommentFormat" value="CHECKSTYLE.ON\: (.+)"/>
         <property name="checkFormat" value="$1"/>
     </module>
+    <module name="SuppressWarningsFilter" />
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
@@ -69,6 +70,7 @@
     <module name="TreeWalker">
         <property name="tabWidth" value="4"/>
 
+        <module name="SuppressWarningsHolder" />
         <module name="FileContentsHolder"/>
 
         <!-- Checks for Javadoc comments.                     -->


### PR DESCRIPTION
via https://github.com/getsentry/raven-java/pull/193

* Rebased off master.
* Suppressed unimportant checkstyle error (too many args in constructor, but it's a a `log4j2` `PluginFactory` anyway)
* Added `serverName` config for JUL.

Also, does this close #175, or was there goal there something different?

