### PR TITLE
Add EventSendFailureCallback, called on send failure.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 7.4.0
 -------------
 
 - Changed default ``raven.async.queuesize`` from unlimited to 50.
+- Add callback system for exceptions raised while attempting to send events.
 
 Version 7.3.0
 -------------

--- a/raven-appengine/src/main/java/com/getsentry/raven/appengine/connection/AppEngineAsyncConnection.java
+++ b/raven-appengine/src/main/java/com/getsentry/raven/appengine/connection/AppEngineAsyncConnection.java
@@ -1,5 +1,6 @@
 package com.getsentry.raven.appengine.connection;
 
+import com.getsentry.raven.connection.EventSendFailureCallback;
 import com.google.appengine.api.taskqueue.DeferredTask;
 import com.google.appengine.api.taskqueue.Queue;
 import com.google.appengine.api.taskqueue.QueueFactory;
@@ -73,6 +74,11 @@ public class AppEngineAsyncConnection implements Connection {
     public void send(Event event) {
         if (!closed)
             queue.add(withPayload(new EventSubmitter(id, event)));
+    }
+
+    @Override
+    public void addEventSendFailureCallback(EventSendFailureCallback eventSendFailureCallback) {
+        actualConnection.addEventSendFailureCallback(eventSendFailureCallback);
     }
 
     /**

--- a/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
@@ -5,7 +5,6 @@ import com.getsentry.raven.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -51,7 +50,8 @@ public abstract class AbstractConnection implements Connection {
     private long baseWaitingTime = DEFAULT_BASE_WAITING_TIME;
     private long waitingTime = baseWaitingTime;
     /**
-     * TODO
+     * Set of callbacks that will be called when an exception occurs while attempting to
+     * send events to the Sentry server.
      */
     private Set<EventSendFailureCallback> eventSendFailureCallbacks;
 
@@ -162,6 +162,12 @@ public abstract class AbstractConnection implements Connection {
         this.baseWaitingTime = baseWaitingTime;
     }
 
+    /**
+     * Add a callback that is called when an exception occurs while attempting to
+     * send events to the Sentry server.
+     *
+     * @param eventSendFailureCallback callback instance
+     */
     public void addEventSendFailureCallback(EventSendFailureCallback eventSendFailureCallback) {
         eventSendFailureCallbacks.add(eventSendFailureCallback);
     }

--- a/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
@@ -86,11 +86,17 @@ public abstract class AbstractConnection implements Connection {
             doSend(event);
             waitingTime = baseWaitingTime;
         } catch (ConnectionException e) {
-            for (EventSendFailureCallback eventSendFailureCallback : eventSendFailureCallbacks) {
-                eventSendFailureCallback.onFailure(event, e);
-            }
             logger.warn("An exception due to the connection occurred, a lockdown will be initiated.", e);
             lockDown();
+
+            for (EventSendFailureCallback eventSendFailureCallback : eventSendFailureCallbacks) {
+                try {
+                    eventSendFailureCallback.onFailure(event, e);
+                } catch (Exception exc) {
+                    logger.warn("An exception occurred while running an EventSendFailureCallback: "
+                        + eventSendFailureCallback.getClass().getName(), exc);
+                }
+            }
         }
     }
 

--- a/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
@@ -85,6 +85,11 @@ public class AsyncConnection implements Connection {
             executorService.execute(new EventSubmitter(event));
     }
 
+    @Override
+    public void addEventSendFailureCallback(EventSendFailureCallback eventSendFailureCallback) {
+        actualConnection.addEventSendFailureCallback(eventSendFailureCallback);
+    }
+
     /**
      * {@inheritDoc}.
      * <p>

--- a/raven/src/main/java/com/getsentry/raven/connection/Connection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/Connection.java
@@ -9,12 +9,18 @@ import java.io.Closeable;
  */
 public interface Connection extends Closeable {
     /**
-     * Sends an event to the sentry server.
+     * Sends an event to the Sentry server.
      *
      * @param event captured event to add in Sentry.
      */
     void send(Event event);
 
+    /**
+     * Add a callback that is called when an exception occurs while attempting to
+     * send events to the Sentry server.
+     *
+     * @param eventSendFailureCallback callback instance
+     */
     void addEventSendFailureCallback(EventSendFailureCallback eventSendFailureCallback);
 
 }

--- a/raven/src/main/java/com/getsentry/raven/connection/Connection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/Connection.java
@@ -14,4 +14,7 @@ public interface Connection extends Closeable {
      * @param event captured event to add in Sentry.
      */
     void send(Event event);
+
+    void addEventSendFailureCallback(EventSendFailureCallback eventSendFailureCallback);
+
 }

--- a/raven/src/main/java/com/getsentry/raven/connection/EventSendFailureCallback.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/EventSendFailureCallback.java
@@ -1,0 +1,9 @@
+package com.getsentry.raven.connection;
+
+import com.getsentry.raven.event.Event;
+
+public interface EventSendFailureCallback {
+
+    void onFailure(Event event, Exception exception);
+
+}

--- a/raven/src/main/java/com/getsentry/raven/connection/EventSendFailureCallback.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/EventSendFailureCallback.java
@@ -2,8 +2,19 @@ package com.getsentry.raven.connection;
 
 import com.getsentry.raven.event.Event;
 
+/**
+ * Callback that is called when an exception occurs while attempting to
+ * send events to the Sentry server.
+ */
 public interface EventSendFailureCallback {
 
+    /**
+     * Called when an exception occurs while attempting to
+     * send events to the Sentry server.
+     *
+     * @param event Event that couldn't be sent
+     * @param exception Exception that occurred while attempting to send the Event
+     */
     void onFailure(Event event, Exception exception);
 
 }

--- a/raven/src/test/java/com/getsentry/raven/connection/EventSendFailureCallbackTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/EventSendFailureCallbackTest.java
@@ -1,0 +1,66 @@
+package com.getsentry.raven.connection;
+
+import com.getsentry.raven.DefaultRavenFactory;
+import com.getsentry.raven.Raven;
+import com.getsentry.raven.dsn.Dsn;
+import com.getsentry.raven.event.Event;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class EventSendFailureCallbackTest {
+
+    @Test
+    public void testSimpleCallback() {
+        final AtomicBoolean flag = new AtomicBoolean(false);
+
+        DefaultRavenFactory factory = new DefaultRavenFactory() {
+            @Override
+            protected Connection createConnection(Dsn dsn) {
+                Connection connection = super.createConnection(dsn);
+
+                connection.addEventSendFailureCallback(new EventSendFailureCallback() {
+                    @Override
+                    public void onFailure(Event event, Exception exception) {
+                        flag.set(true);
+                    }
+                });
+
+                return connection;
+            }
+        };
+
+        String dsn = "https://foo:bar@localhost:1234/1?raven.async=false";
+        Raven raven = factory.createRavenInstance(new Dsn(dsn));
+        raven.sendMessage("Message that will fail because DSN points to garbage.");
+
+        assertThat(flag.get(), is(true));
+    }
+
+    @Test
+    public void testExceptionInsideCallback() {
+        DefaultRavenFactory factory = new DefaultRavenFactory() {
+            @Override
+            protected Connection createConnection(Dsn dsn) {
+                Connection connection = super.createConnection(dsn);
+
+                connection.addEventSendFailureCallback(new EventSendFailureCallback() {
+                    @Override
+                    public void onFailure(Event event, Exception exception) {
+                        throw new RuntimeException("Error inside of EventSendFailureCallback");
+                    }
+                });
+
+                return connection;
+            }
+        };
+
+        String dsn = "https://foo:bar@localhost:1234/1?raven.async=false";
+        Raven raven = factory.createRavenInstance(new Dsn(dsn));
+        raven.sendMessage("Message that will fail because DSN points to garbage.");
+    }
+
+}


### PR DESCRIPTION
This is a first stab at #180 to get feedback on the general idea. As usual, naming is hard.

Tests pass, failure is Javadoc crap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-java/201)
<!-- Reviewable:end -->
