### PR TITLE
Initial breadcrumbs implementation.

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
@@ -2,6 +2,7 @@ package com.getsentry.raven;
 
 import com.getsentry.raven.connection.*;
 import com.getsentry.raven.dsn.Dsn;
+import com.getsentry.raven.event.helper.ContextBuilderHelper;
 import com.getsentry.raven.event.helper.HttpEventBuilderHelper;
 import com.getsentry.raven.event.interfaces.*;
 import com.getsentry.raven.marshaller.Marshaller;
@@ -75,6 +76,7 @@ public class DefaultRavenFactory extends RavenFactory {
             // https://tomcat.apache.org/tomcat-5.5-doc/servletapi/
             Class.forName("javax.servlet.ServletRequestListener", false, this.getClass().getClassLoader());
             raven.addBuilderHelper(new HttpEventBuilderHelper());
+            raven.addBuilderHelper(new ContextBuilderHelper(raven));
         } catch (ClassNotFoundException e) {
             logger.debug("The current environment doesn't provide access to servlets,"
                          + "or provides an unsupported version.");

--- a/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
@@ -76,11 +76,11 @@ public class DefaultRavenFactory extends RavenFactory {
             // https://tomcat.apache.org/tomcat-5.5-doc/servletapi/
             Class.forName("javax.servlet.ServletRequestListener", false, this.getClass().getClassLoader());
             raven.addBuilderHelper(new HttpEventBuilderHelper());
-            raven.addBuilderHelper(new ContextBuilderHelper(raven));
         } catch (ClassNotFoundException e) {
             logger.debug("The current environment doesn't provide access to servlets,"
                          + "or provides an unsupported version.");
         }
+        raven.addBuilderHelper(new ContextBuilderHelper(raven));
         return raven;
     }
 

--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -25,14 +25,12 @@ public class Raven {
     private static final Logger logger = LoggerFactory.getLogger(Raven.class);
     private final Set<EventBuilderHelper> builderHelpers = new HashSet<>();
     private Connection connection;
-    private RavenContext context;
-
-    /**
-     * Create a Raven object with an empty {@link RavenContext}.
-     */
-    public Raven() {
-        context = new RavenContext();
-    }
+    private ThreadLocal<RavenContext> context = new ThreadLocal<RavenContext>() {
+        @Override
+        protected RavenContext initialValue() {
+            return new RavenContext();
+        }
+    };
 
     /**
      * Runs the {@link EventBuilderHelper} against the {@link EventBuilder} to obtain additional information with a
@@ -128,7 +126,7 @@ public class Raven {
     }
 
     public RavenContext getContext() {
-        return context;
+        return context.get();
     }
 
     @Override

--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -25,6 +25,14 @@ public class Raven {
     private static final Logger logger = LoggerFactory.getLogger(Raven.class);
     private final Set<EventBuilderHelper> builderHelpers = new HashSet<>();
     private Connection connection;
+    private RavenContext context;
+
+    /**
+     * Create a Raven object with an empty {@link RavenContext}.
+     */
+    public Raven() {
+        context = new RavenContext();
+    }
 
     /**
      * Runs the {@link EventBuilderHelper} against the {@link EventBuilder} to obtain additional information with a
@@ -117,6 +125,10 @@ public class Raven {
 
     public void setConnection(Connection connection) {
         this.connection = connection;
+    }
+
+    public RavenContext getContext() {
+        return context;
     }
 
     @Override

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class RavenContext implements AutoCloseable {
 
     /**
-     * Thread local set of activate context objects. Note that an {@link IdentityHashMap}
+     * Thread local set of active context objects. Note that an {@link IdentityHashMap}
      * is used instead of a Set because there is no identity-set in the Java
      * standard library.
      */

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -15,6 +15,7 @@ import java.util.List;
  * of an application and then sent together when (e.g.) an exception occurs.
  */
 public class RavenContext implements AutoCloseable {
+
     /**
      * Thread local set of activate context objects. Note that an {@link IdentityHashMap}
      * is used instead of a Set because there is no identity-set in the Java
@@ -27,10 +28,12 @@ public class RavenContext implements AutoCloseable {
                 return new IdentityHashMap<>();
             }
     };
+
     /**
      * The number of {@link Breadcrumb}s to keep in the ring buffer by default.
      */
     private static final int DEFAULT_BREADCRUMB_LIMIT = 100;
+
     /**
      * Ring buffer of {@link Breadcrumb} objects.
      */

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -90,4 +90,13 @@ public class RavenContext implements AutoCloseable {
         return breadcrumbs.iterator();
     }
 
+    /**
+     * Record a single {@link Breadcrumb} into this context.
+     *
+     * @param breadcrumb Breadcrumb object to record
+     */
+    public void recordBreadcrumb(Breadcrumb breadcrumb) {
+        breadcrumbs.add(breadcrumb);
+    }
+
 }

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -74,8 +74,6 @@ public class RavenContext implements AutoCloseable {
      */
     public void clear() {
         breadcrumbs.clear();
-        // TODO: deactivate if not main thread id like python does?
-        //   https://github.com/getsentry/raven-python/blob/master/raven/context.py#L127-L133
     }
 
     /**

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -40,11 +40,19 @@ public class RavenContext implements AutoCloseable {
     private CircularFifoQueue<Breadcrumb> breadcrumbs;
 
     /**
-     * Create a new (empty) RavenContext object.
+     * Create a new (empty) RavenContext object with the default Breadcrumb limit.
      */
     public RavenContext() {
-        // TODO: ringbuffer size parameter
-        breadcrumbs = new CircularFifoQueue<>(DEFAULT_BREADCRUMB_LIMIT);
+        this(DEFAULT_BREADCRUMB_LIMIT);
+    }
+
+    /**
+     * Create a new (empty) RavenContext object with the specified Breadcrumb limit.
+     *
+     * @param breadcrumbLimit Number of Breadcrumb objects to retain in ring buffer.
+     */
+    public RavenContext(int breadcrumbLimit) {
+        breadcrumbs = new CircularFifoQueue<>(breadcrumbLimit);
     }
 
     /**

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -1,0 +1,89 @@
+package com.getsentry.raven;
+
+import com.getsentry.raven.event.Breadcrumb;
+import com.getsentry.raven.util.CircularFifoQueue;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * RavenContext is used to hold {@link ThreadLocal} context data (such as
+ * {@link Breadcrumb}s) so that data may be collected in different parts
+ * of an appliation and then sent together when (e.g.) an exception occurs.
+ */
+public class RavenContext implements AutoCloseable {
+
+    /**
+     * Thread local set of activate context objects. Note that a {@link ConcurrentHashMap}
+     * is used here because no Concurrent Set exists in the Java standard library.
+     * We use the same object for the Key and the Value and treat it like a Set.
+     */
+    private static ThreadLocal<ConcurrentHashMap<RavenContext, RavenContext>> activeContexts =
+        new ThreadLocal<ConcurrentHashMap<RavenContext, RavenContext>>() {
+            @Override
+            protected ConcurrentHashMap<RavenContext, RavenContext> initialValue() {
+                return new ConcurrentHashMap<>();
+            }
+    };
+
+    /**
+     * Ring buffer of {@link Breadcrumb} objects.
+     */
+    private CircularFifoQueue<Breadcrumb> breadcrumbs;
+
+    /**
+     * Create a new (empty) RavenContext object.
+     */
+    public RavenContext() {
+        // TODO: ringbuffer size parameter
+        breadcrumbs = new CircularFifoQueue<>(100);
+    }
+
+    /**
+     * Add this context to the activate contexts for this thread.
+     */
+    public void activate() {
+        activeContexts.get().put(this, this);
+    }
+
+    /**
+     * Remove this context from the activate contexts for this thread.
+     */
+    public void deactivate() {
+        activeContexts.get().remove(this);
+    }
+
+    /**
+     * Clear state from this context.
+     */
+    public void clear() {
+        breadcrumbs.clear();
+        // TODO: deactivate if not main thread id like python does?
+        //   https://github.com/getsentry/raven-python/blob/master/raven/context.py#L127-L133
+    }
+
+    /**
+     * Calls deactivate, used by try-with-resources ({@link AutoCloseable}).
+     *
+     * @throws Exception
+     */
+    @Override
+    public void close() throws Exception {
+        deactivate();
+    }
+
+    /**
+     * Returns all activate contexts for the current thread.
+     *
+     * @return Set of active {@link RavenContext} objects.
+     */
+    public static Set<RavenContext> getActiveContexts() {
+        return Collections.unmodifiableSet(activeContexts.get().keySet());
+    }
+
+    public CircularFifoQueue<Breadcrumb> getBreadcrumbs() {
+        return breadcrumbs;
+    }
+
+}

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
@@ -1,6 +1,7 @@
 package com.getsentry.raven.event;
 
 import java.util.Date;
+import java.util.Map;
 
 /**
  * An object that represents a single breadcrumb. Events may include a list
@@ -35,6 +36,11 @@ public class Breadcrumb {
     private final String category;
 
     /**
+     * Data related to the breadcrumb.
+     */
+    private final Map<String, String> data;
+
+    /**
      * Create an immutable {@link Breadcrumb} object.
      *
      * @param type String
@@ -43,15 +49,21 @@ public class Breadcrumb {
      * @param level String
      * @param message String
      * @param category String
+     * @param data Map of String to String
      */
-    Breadcrumb(String type, Date timestamp, float duration, String level, String message, String category) {
+    Breadcrumb(String type, Date timestamp, float duration, String level, String message,
+        String category, Map<String, String> data) {
+
         if (timestamp == null) {
             timestamp = new Date();
         }
 
         checkNotNull(level, "level");
-        checkNotNull(message, "message");
         checkNotNull(category, "category");
+
+        if (message == null && (data == null || data.size() < 1)) {
+            throw new IllegalArgumentException("one of 'message' or 'data' must be set");
+        }
 
         this.type = type;
         this.timestamp = timestamp;
@@ -59,11 +71,12 @@ public class Breadcrumb {
         this.level = level;
         this.message = message;
         this.category = category;
+        this.data = data;
     }
 
     private void checkNotNull(String str, String name) {
-        if (str == null || str.trim().equals("")) {
-            throw new IllegalArgumentException("field '" + name + "' is required but set to '" + str + "'");
+        if (str == null) {
+            throw new IllegalArgumentException("field '" + name + "' is required but got null");
         }
     }
 
@@ -89,6 +102,10 @@ public class Breadcrumb {
 
     public String getCategory() {
         return category;
+    }
+
+    public Map<String, String> getData() {
+        return data;
     }
 
 }

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
@@ -30,7 +30,6 @@ public class Breadcrumb {
      * Category of the breadcrumb.
      */
     private final String category;
-
     /**
      * Data related to the breadcrumb.
      */

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
@@ -19,10 +19,6 @@ public class Breadcrumb {
      */
     private final Date timestamp;
     /**
-     * (Optional) Duration of the portion this breadcrumb represents.
-     */
-    private final float duration;
-    /**
      * Level of the breadcrumb.
      */
     private final String level;
@@ -45,13 +41,12 @@ public class Breadcrumb {
      *
      * @param type String
      * @param timestamp Date
-     * @param duration float
      * @param level String
      * @param message String
      * @param category String
      * @param data Map of String to String
      */
-    Breadcrumb(String type, Date timestamp, float duration, String level, String message,
+    Breadcrumb(String type, Date timestamp, String level, String message,
         String category, Map<String, String> data) {
 
         if (timestamp == null) {
@@ -67,7 +62,6 @@ public class Breadcrumb {
 
         this.type = type;
         this.timestamp = timestamp;
-        this.duration = duration;
         this.level = level;
         this.message = message;
         this.category = category;
@@ -86,10 +80,6 @@ public class Breadcrumb {
 
     public Date getTimestamp() {
         return timestamp;
-    }
-
-    public float getDuration() {
-        return duration;
     }
 
     public String getLevel() {

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
@@ -1,0 +1,94 @@
+package com.getsentry.raven.event;
+
+import java.util.Date;
+
+/**
+ * An object that represents a single breadcrumb. Events may include a list
+ * of breadcrumbs that help users re-create the path of actions that occurred
+ * which lead to the Event happening.
+ */
+public class Breadcrumb {
+
+    /**
+     * (Optional) Type of the breadcrumb.
+     */
+    private final String type;
+    /**
+     * Timestamp when the breadcrumb occurred.
+     */
+    private final Date timestamp;
+    /**
+     * (Optional) Duration of the portion this breadcrumb represents.
+     */
+    private final float duration;
+    /**
+     * Level of the breadcrumb.
+     */
+    private final String level;
+    /**
+     * Message of the breadcrumb.
+     */
+    private final String message;
+    /**
+     * Category of the breadcrumb.
+     */
+    private final String category;
+
+    /**
+     * Create an immutable {@link Breadcrumb} object.
+     *
+     * @param type String
+     * @param timestamp Date
+     * @param duration float
+     * @param level String
+     * @param message String
+     * @param category String
+     */
+    Breadcrumb(String type, Date timestamp, float duration, String level, String message, String category) {
+        if (timestamp == null) {
+            timestamp = new Date();
+        }
+
+        checkNotNull(level, "level");
+        checkNotNull(message, "message");
+        checkNotNull(category, "category");
+
+        this.type = type;
+        this.timestamp = timestamp;
+        this.duration = duration;
+        this.level = level;
+        this.message = message;
+        this.category = category;
+    }
+
+    private void checkNotNull(String str, String name) {
+        if (str == null || str.trim().equals("")) {
+            throw new IllegalArgumentException("field '" + name + "' is required but set to '" + str + "'");
+        }
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public float getDuration() {
+        return duration;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+}

--- a/raven/src/main/java/com/getsentry/raven/event/BreadcrumbBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/BreadcrumbBuilder.java
@@ -1,0 +1,92 @@
+package com.getsentry.raven.event;
+
+import java.util.Date;
+
+/**
+ * Builder to assist the creation of {@link Breadcrumb}s.
+ */
+public class BreadcrumbBuilder {
+
+    private String type;
+    private Date timestamp;
+    private float duration;
+    private String level;
+    private String message;
+    private String category;
+
+    /**
+     * Type of the {@link Breadcrumb}.
+     *
+     * @param newType String
+     * @return current BreadcrumbBuilder
+     */
+    public BreadcrumbBuilder setType(String newType) {
+        this.type = newType;
+        return this;
+    }
+
+    /**
+     * Timestamp of the {@link Breadcrumb}.
+     *
+     * @param newTimestamp Date
+     * @return current BreadcrumbBuilder
+     */
+    public BreadcrumbBuilder setTimestamp(Date newTimestamp) {
+        this.timestamp = newTimestamp;
+        return this;
+    }
+
+    /**
+     * Duration of the {@link Breadcrumb}.
+     *
+     * @param newDuration float
+     * @return current BreadcrumbBuilder
+     */
+    public BreadcrumbBuilder setDuration(float newDuration) {
+        this.duration = newDuration;
+        return this;
+    }
+
+    /**
+     * Level of the {@link Breadcrumb}.
+     *
+     * @param newLevel String
+     * @return current BreadcrumbBuilder
+     */
+    public BreadcrumbBuilder setLevel(String newLevel) {
+        this.level = newLevel;
+        return this;
+    }
+
+    /**
+     * Message of the {@link Breadcrumb}.
+     *
+     * @param newMessage String
+     * @return current BreadcrumbBuilder
+     */
+    public BreadcrumbBuilder setMessage(String newMessage) {
+        this.message = newMessage;
+        return this;
+    }
+
+    /**
+     * Category of the {@link Breadcrumb}.
+     *
+     * @param newCategory String
+     * @return current BreadcrumbBuilder
+     */
+    public BreadcrumbBuilder setCategory(String newCategory) {
+        this.category = newCategory;
+        return this;
+    }
+
+    /**
+     * Build and return the {@link Breadcrumb} object.
+     *
+     * @return Breadcrumb
+     */
+    public Breadcrumb build() {
+        return new Breadcrumb(type, timestamp, duration, level, message, category);
+    }
+
+}

--- a/raven/src/main/java/com/getsentry/raven/event/BreadcrumbBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/BreadcrumbBuilder.java
@@ -10,7 +10,6 @@ public class BreadcrumbBuilder {
 
     private String type;
     private Date timestamp;
-    private float duration;
     private String level;
     private String message;
     private String category;
@@ -35,17 +34,6 @@ public class BreadcrumbBuilder {
      */
     public BreadcrumbBuilder setTimestamp(Date newTimestamp) {
         this.timestamp = newTimestamp;
-        return this;
-    }
-
-    /**
-     * Duration of the {@link Breadcrumb}.
-     *
-     * @param newDuration float
-     * @return current BreadcrumbBuilder
-     */
-    public BreadcrumbBuilder setDuration(float newDuration) {
-        this.duration = newDuration;
         return this;
     }
 
@@ -101,7 +89,7 @@ public class BreadcrumbBuilder {
      * @return Breadcrumb
      */
     public Breadcrumb build() {
-        return new Breadcrumb(type, timestamp, duration, level, message, category, data);
+        return new Breadcrumb(type, timestamp, level, message, category, data);
     }
 
 }

--- a/raven/src/main/java/com/getsentry/raven/event/BreadcrumbBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/BreadcrumbBuilder.java
@@ -1,6 +1,7 @@
 package com.getsentry.raven.event;
 
 import java.util.Date;
+import java.util.Map;
 
 /**
  * Builder to assist the creation of {@link Breadcrumb}s.
@@ -13,6 +14,7 @@ public class BreadcrumbBuilder {
     private String level;
     private String message;
     private String category;
+    private Map<String, String> data;
 
     /**
      * Type of the {@link Breadcrumb}.
@@ -59,7 +61,8 @@ public class BreadcrumbBuilder {
     }
 
     /**
-     * Message of the {@link Breadcrumb}.
+     * Message of the {@link Breadcrumb}. At least one of message or
+     * data is required.
      *
      * @param newMessage String
      * @return current BreadcrumbBuilder
@@ -81,12 +84,24 @@ public class BreadcrumbBuilder {
     }
 
     /**
+     * Data related to the {@link Breadcrumb}. At least one of message or
+     * data is required.
+     *
+     * @param newData Map of String to String
+     * @return current BreadcrumbBuilder
+     */
+    public BreadcrumbBuilder setData(Map<String, String> newData) {
+        this.data = newData;
+        return this;
+    }
+
+    /**
      * Build and return the {@link Breadcrumb} object.
      *
      * @return Breadcrumb
      */
     public Breadcrumb build() {
-        return new Breadcrumb(type, timestamp, duration, level, message, category);
+        return new Breadcrumb(type, timestamp, duration, level, message, category, data);
     }
 
 }

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumbs.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumbs.java
@@ -1,0 +1,28 @@
+package com.getsentry.raven.event;
+
+import com.getsentry.raven.RavenContext;
+
+/**
+ * Helpers for dealing with {@link Breadcrumb}s.
+ */
+public final class Breadcrumbs {
+
+    /**
+     * Private constructor because this is a utility class.
+     */
+    private Breadcrumbs() {
+
+    }
+
+    /**
+     * Record a {@link Breadcrumb} into all of this thread's activate contexts.
+     *
+     * @param breadcrumb Breadcrumb to record
+     */
+    public static void record(Breadcrumb breadcrumb) {
+        for (RavenContext context : RavenContext.getActiveContexts()) {
+            context.recordBreadcrumb(breadcrumb);
+        }
+    }
+
+}

--- a/raven/src/main/java/com/getsentry/raven/event/Event.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Event.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -63,6 +64,10 @@ public class Event implements Serializable {
      * Automatically created with a Map that is made unmodifiable by the {@link EventBuilder}.
      */
     private Map<String, String> tags = new HashMap<>();
+    /**
+     * List of Breadcrumb objects related to the event.
+     */
+    private List<Breadcrumb> breadcrumbs = new ArrayList<>();
     /**
      * Identifies the host client from which the event was recorded.
      */
@@ -157,6 +162,14 @@ public class Event implements Serializable {
 
     void setCulprit(String culprit) {
         this.culprit = culprit;
+    }
+
+    public List<Breadcrumb> getBreadcrumbs() {
+        return breadcrumbs;
+    }
+
+    void setBreadcrumbs(List<Breadcrumb> breadcrumbs) {
+        this.breadcrumbs = breadcrumbs;
     }
 
     public Map<String, String> getTags() {

--- a/raven/src/main/java/com/getsentry/raven/event/Event.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Event.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -64,10 +63,6 @@ public class Event implements Serializable {
      * Automatically created with a Map that is made unmodifiable by the {@link EventBuilder}.
      */
     private Map<String, String> tags = new HashMap<>();
-    /**
-     * List of Breadcrumb objects related to the event.
-     */
-    private List<Breadcrumb> breadcrumbs = new ArrayList<>();
     /**
      * Identifies the host client from which the event was recorded.
      */
@@ -162,14 +157,6 @@ public class Event implements Serializable {
 
     void setCulprit(String culprit) {
         this.culprit = culprit;
-    }
-
-    public List<Breadcrumb> getBreadcrumbs() {
-        return breadcrumbs;
-    }
-
-    void setBreadcrumbs(List<Breadcrumb> breadcrumbs) {
-        this.breadcrumbs = breadcrumbs;
     }
 
     public Map<String, String> getTags() {

--- a/raven/src/main/java/com/getsentry/raven/event/EventBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/EventBuilder.java
@@ -99,9 +99,6 @@ public class EventBuilder {
         // Make the tags unmodifiable
         event.setTags(Collections.unmodifiableMap(event.getTags()));
 
-        // Make the breadcrumbs unmodifiable
-        event.setBreadcrumbs(Collections.unmodifiableList(event.getBreadcrumbs()));
-
         // Make the extra properties unmodifiable (everything in it is still mutable though)
         event.setExtra(Collections.unmodifiableMap(event.getExtra()));
 
@@ -221,17 +218,6 @@ public class EventBuilder {
      */
     public EventBuilder withTag(String tagKey, String tagValue) {
         event.getTags().put(tagKey, tagValue);
-        return this;
-    }
-
-    /**
-     * Adds a list of {@code Breadcrumb}s to the event.
-     *
-     * @param breadcrumbs list of breadcrumbs
-     * @return the current {@code EventBuilder} for chained calls.
-     */
-    public EventBuilder withBreadcrumbs(List<Breadcrumb> breadcrumbs) {
-        event.setBreadcrumbs(breadcrumbs);
         return this;
     }
 

--- a/raven/src/main/java/com/getsentry/raven/event/EventBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/EventBuilder.java
@@ -99,6 +99,9 @@ public class EventBuilder {
         // Make the tags unmodifiable
         event.setTags(Collections.unmodifiableMap(event.getTags()));
 
+        // Make the breadcrumbs unmodifiable
+        event.setBreadcrumbs(Collections.unmodifiableList(event.getBreadcrumbs()));
+
         // Make the extra properties unmodifiable (everything in it is still mutable though)
         event.setExtra(Collections.unmodifiableMap(event.getExtra()));
 
@@ -218,6 +221,17 @@ public class EventBuilder {
      */
     public EventBuilder withTag(String tagKey, String tagValue) {
         event.getTags().put(tagKey, tagValue);
+        return this;
+    }
+
+    /**
+     * Adds a list of {@code Breadcrumb}s to the event.
+     *
+     * @param breadcrumbs list of breadcrumbs
+     * @return the current {@code EventBuilder} for chained calls.
+     */
+    public EventBuilder withBreadcrumbs(List<Breadcrumb> breadcrumbs) {
+        event.setBreadcrumbs(breadcrumbs);
         return this;
     }
 

--- a/raven/src/main/java/com/getsentry/raven/event/helper/ContextBuilderHelper.java
+++ b/raven/src/main/java/com/getsentry/raven/event/helper/ContextBuilderHelper.java
@@ -1,0 +1,41 @@
+package com.getsentry.raven.event.helper;
+
+import com.getsentry.raven.Raven;
+import com.getsentry.raven.event.Breadcrumb;
+import com.getsentry.raven.event.EventBuilder;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * {@link EventBuilderHelper} that extracts and sends any data attached to the
+ * provided {@link Raven}'s {@link com.getsentry.raven.RavenContext}.
+ */
+public class ContextBuilderHelper implements EventBuilderHelper {
+
+    /**
+     * Raven object where the RavenContext comes from.
+     */
+    private Raven raven;
+
+    /**
+     * {@link EventBuilderHelper} that extracts context data from the provided {@link Raven} client.
+     *
+     * @param raven Raven client which holds RavenContext to be used.
+     */
+    public ContextBuilderHelper(Raven raven) {
+        this.raven = raven;
+    }
+
+    @Override
+    public void helpBuildingEvent(EventBuilder eventBuilder) {
+        List<Breadcrumb> breadcrumbs = new ArrayList<>();
+        Iterator<Breadcrumb> iter = raven.getContext().getBreadcrumbs();
+        while (iter.hasNext()) {
+            breadcrumbs.add(iter.next());
+        }
+        eventBuilder.withBreadcrumbs(breadcrumbs);
+    }
+
+}

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -135,7 +135,7 @@ public class JsonMarshaller implements Marshaller {
         generator.writeStringField(PLATFORM, event.getPlatform());
         generator.writeStringField(CULPRIT, event.getCulprit());
         writeTags(generator, event.getTags());
-        writeBreadcumbs(generator, event.getBreadcrumbs());
+        // TODO: write out context?
         generator.writeStringField(SERVER_NAME, event.getServerName());
         generator.writeStringField(RELEASE, event.getRelease());
         writeExtras(generator, event.getExtra());
@@ -227,6 +227,11 @@ public class JsonMarshaller implements Marshaller {
             generator.writeStringField(tag.getKey(), tag.getValue());
         }
         generator.writeEndObject();
+    }
+
+    private void writeContext(JsonGenerator generator) throws IOException {
+        // TODO: which context? all activate contexts for this thread?
+        // TODO: for each (?) context: writeBreadcrumbs
     }
 
     @SuppressWarnings("checkstyle:magicnumber")

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -239,20 +239,30 @@ public class JsonMarshaller implements Marshaller {
         generator.writeArrayFieldStart("values");
         for (Breadcrumb breadcrumb : breadcrumbs) {
             generator.writeStartObject();
+            // getTime() returns ts in millis, but breadcrumbs expect seconds
+            generator.writeNumberField("timestamp", breadcrumb.getTimestamp().getTime() / 1000);
+
             if (breadcrumb.getType() != null) {
                 generator.writeStringField("type", breadcrumb.getType());
             }
-            // getTime() returns ts in millis, but breadcrumbs expect seconds
-            generator.writeNumberField("timestamp", breadcrumb.getTimestamp().getTime() / 1000);
             if (breadcrumb.getDuration() != 0.0) {
                 generator.writeNumberField("duration", breadcrumb.getDuration());
             }
             if (breadcrumb.getLevel() != null) {
                 generator.writeStringField("level", breadcrumb.getLevel());
             }
-            generator.writeStringField("message", breadcrumb.getMessage());
+            if (breadcrumb.getMessage() != null) {
+                generator.writeStringField("message", breadcrumb.getMessage());
+            }
             if (breadcrumb.getCategory() != null) {
                 generator.writeStringField("category", breadcrumb.getCategory());
+            }
+            if (breadcrumb.getData() != null && breadcrumb.getData().size() > 0) {
+                generator.writeObjectFieldStart("data");
+                for (Map.Entry<String, String> entry : breadcrumb.getData().entrySet()) {
+                    generator.writeStringField(entry.getKey(), entry.getValue());
+                }
+                generator.writeEndObject();
             }
             generator.writeEndObject();
         }

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -135,7 +135,7 @@ public class JsonMarshaller implements Marshaller {
         generator.writeStringField(PLATFORM, event.getPlatform());
         generator.writeStringField(CULPRIT, event.getCulprit());
         writeTags(generator, event.getTags());
-        // TODO: write out context?
+        writeBreadcumbs(generator, event.getBreadcrumbs());
         generator.writeStringField(SERVER_NAME, event.getServerName());
         generator.writeStringField(RELEASE, event.getRelease());
         writeExtras(generator, event.getExtra());
@@ -227,11 +227,6 @@ public class JsonMarshaller implements Marshaller {
             generator.writeStringField(tag.getKey(), tag.getValue());
         }
         generator.writeEndObject();
-    }
-
-    private void writeContext(JsonGenerator generator) throws IOException {
-        // TODO: which context? all activate contexts for this thread?
-        // TODO: for each (?) context: writeBreadcrumbs
     }
 
     @SuppressWarnings("checkstyle:magicnumber")

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -245,9 +245,6 @@ public class JsonMarshaller implements Marshaller {
             if (breadcrumb.getType() != null) {
                 generator.writeStringField("type", breadcrumb.getType());
             }
-            if (breadcrumb.getDuration() != 0.0) {
-                generator.writeNumberField("duration", breadcrumb.getDuration());
-            }
             if (breadcrumb.getLevel() != null) {
                 generator.writeStringField("level", breadcrumb.getLevel());
             }

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -2,6 +2,7 @@ package com.getsentry.raven.marshaller.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.getsentry.raven.event.Breadcrumb;
 import com.getsentry.raven.util.Base64;
 import com.getsentry.raven.util.Base64OutputStream;
 import com.getsentry.raven.event.Event;
@@ -56,6 +57,10 @@ public class JsonMarshaller implements Marshaller {
      * A map or list of tags for this event.
      */
     public static final String TAGS = "tags";
+    /**
+     * List of breadcrumbs for this event.
+     */
+    public static final String BREADCRUMBS = "breadcrumbs";
     /**
      * Identifies the host client from which the event was recorded.
      */
@@ -130,6 +135,7 @@ public class JsonMarshaller implements Marshaller {
         generator.writeStringField(PLATFORM, event.getPlatform());
         generator.writeStringField(CULPRIT, event.getCulprit());
         writeTags(generator, event.getTags());
+        writeBreadcumbs(generator, event.getBreadcrumbs());
         generator.writeStringField(SERVER_NAME, event.getServerName());
         generator.writeStringField(RELEASE, event.getRelease());
         writeExtras(generator, event.getExtra());
@@ -220,6 +226,37 @@ public class JsonMarshaller implements Marshaller {
         for (Map.Entry<String, String> tag : tags.entrySet()) {
             generator.writeStringField(tag.getKey(), tag.getValue());
         }
+        generator.writeEndObject();
+    }
+
+    @SuppressWarnings("checkstyle:magicnumber")
+    private void writeBreadcumbs(JsonGenerator generator, List<Breadcrumb> breadcrumbs) throws IOException {
+        if (breadcrumbs.size() < 1) {
+            return;
+        }
+
+        generator.writeObjectFieldStart(BREADCRUMBS);
+        generator.writeArrayFieldStart("values");
+        for (Breadcrumb breadcrumb : breadcrumbs) {
+            generator.writeStartObject();
+            if (breadcrumb.getType() != null) {
+                generator.writeStringField("type", breadcrumb.getType());
+            }
+            // getTime() returns ts in millis, but breadcrumbs expect seconds
+            generator.writeNumberField("timestamp", breadcrumb.getTimestamp().getTime() / 1000);
+            if (breadcrumb.getDuration() != 0.0) {
+                generator.writeNumberField("duration", breadcrumb.getDuration());
+            }
+            if (breadcrumb.getLevel() != null) {
+                generator.writeStringField("level", breadcrumb.getLevel());
+            }
+            generator.writeStringField("message", breadcrumb.getMessage());
+            if (breadcrumb.getCategory() != null) {
+                generator.writeStringField("category", breadcrumb.getCategory());
+            }
+            generator.writeEndObject();
+        }
+        generator.writeEndArray();
         generator.writeEndObject();
     }
 

--- a/raven/src/main/java/com/getsentry/raven/util/CircularFifoQueue.java
+++ b/raven/src/main/java/com/getsentry/raven/util/CircularFifoQueue.java
@@ -1,0 +1,426 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getsentry.raven.util;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+/**
+ * CircularFifoQueue is a first-in first-out queue with a fixed size that
+ * replaces its oldest element if full.
+ * <p>
+ * The removal order of a {@link CircularFifoQueue} is based on the
+ * insertion order; elements are removed in the same order in which they
+ * were added.  The iteration order is the same as the removal order.
+ * <p>
+ * The {@link #add(Object)}, {@link #remove()}, {@link #peek()}, {@link #poll},
+ * {@link #offer(Object)} operations all perform in constant time.
+ * All other operations perform in linear time or worse.
+ * <p>
+ * This queue prevents null objects from being added.
+ *
+ * @since 4.0
+ * @version $Id$
+ */
+public class CircularFifoQueue<E> extends AbstractCollection<E>
+    implements Queue<E>, Serializable {
+
+    /** Serialization version. */
+    private static final long serialVersionUID = -8423413834657610406L;
+
+    /** Underlying storage array. */
+    private transient E[] elements;
+
+    /** Array index of first (oldest) queue element. */
+    private transient int start = 0;
+
+    /**
+     * Index mod maxElements of the array position following the last queue
+     * element.  Queue elements start at elements[start] and "wrap around"
+     * elements[maxElements-1], ending at elements[decrement(end)].
+     * For example, elements = {c,a,b}, start=1, end=1 corresponds to
+     * the queue [a,b,c].
+     */
+    private transient int end = 0;
+
+    /** Flag to indicate if the queue is currently full. */
+    private transient boolean full = false;
+
+    /** Capacity of the queue. */
+    private final int maxElements;
+
+    /**
+     * Constructor that creates a queue with the default size of 32.
+     */
+    public CircularFifoQueue() {
+        this(32);
+    }
+
+    /**
+     * Constructor that creates a queue with the specified size.
+     *
+     * @param size  the size of the queue (cannot be changed)
+     * @throws IllegalArgumentException  if the size is &lt; 1
+     */
+    @SuppressWarnings("unchecked")
+    public CircularFifoQueue(final int size) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("The size must be greater than 0");
+        }
+        elements = (E[]) new Object[size];
+        maxElements = elements.length;
+    }
+
+    /**
+     * Constructor that creates a queue from the specified collection.
+     * The collection size also sets the queue size.
+     *
+     * @param coll  the collection to copy into the queue, may not be null
+     * @throws NullPointerException if the collection is null
+     */
+    public CircularFifoQueue(final Collection<? extends E> coll) {
+        this(coll.size());
+        addAll(coll);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Write the queue out using a custom routine.
+     *
+     * @param out  the output stream
+     * @throws IOException if an I/O error occurs while writing to the output stream
+     */
+    private void writeObject(final ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+        out.writeInt(size());
+        for (final E e : this) {
+            out.writeObject(e);
+        }
+    }
+
+    /**
+     * Read the queue in using a custom routine.
+     *
+     * @param in  the input stream
+     * @throws IOException if an I/O error occurs while writing to the output stream
+     * @throws ClassNotFoundException if the class of a serialized object can not be found
+     */
+    @SuppressWarnings("unchecked")
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        elements = (E[]) new Object[maxElements];
+        final int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            elements[i] = (E) in.readObject();
+        }
+        start = 0;
+        full = size == maxElements;
+        if (full) {
+            end = 0;
+        } else {
+            end = size;
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns the number of elements stored in the queue.
+     *
+     * @return this queue's size
+     */
+    @Override
+    public int size() {
+        int size = 0;
+
+        if (end < start) {
+            size = maxElements - start + end;
+        } else if (end == start) {
+            size = full ? maxElements : 0;
+        } else {
+            size = end - start;
+        }
+
+        return size;
+    }
+
+    /**
+     * Returns true if this queue is empty; false otherwise.
+     *
+     * @return true if this queue is empty
+     */
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A {@code CircularFifoQueue} can never be full, thus this returns always
+     * {@code false}.
+     *
+     * @return always returns {@code false}
+     */
+    public boolean isFull() {
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if the capacity limit of this queue has been reached,
+     * i.e. the number of elements stored in the queue equals its maximum size.
+     *
+     * @return {@code true} if the capacity limit has been reached, {@code false} otherwise
+     * @since 4.1
+     */
+    public boolean isAtFullCapacity() {
+        return size() == maxElements;
+    }
+
+    /**
+     * Gets the maximum size of the collection (the bound).
+     *
+     * @return the maximum number of elements the collection can hold
+     */
+    public int maxSize() {
+        return maxElements;
+    }
+
+    /**
+     * Clears this queue.
+     */
+    @Override
+    public void clear() {
+        full = false;
+        start = 0;
+        end = 0;
+        Arrays.fill(elements, null);
+    }
+
+    /**
+     * Adds the given element to this queue. If the queue is full, the least recently added
+     * element is discarded so that a new element can be inserted.
+     *
+     * @param element  the element to add
+     * @return true, always
+     * @throws NullPointerException  if the given element is null
+     */
+    @Override
+    public boolean add(final E element) {
+        if (null == element) {
+            throw new NullPointerException("Attempted to add null object to queue");
+        }
+
+        if (isAtFullCapacity()) {
+            remove();
+        }
+
+        elements[end++] = element;
+
+        if (end >= maxElements) {
+            end = 0;
+        }
+
+        if (end == start) {
+            full = true;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the element at the specified position in this queue.
+     *
+     * @param index the position of the element in the queue
+     * @return the element at position {@code index}
+     * @throws NoSuchElementException if the requested position is outside the range [0, size)
+     */
+    public E get(final int index) {
+        final int sz = size();
+        if (index < 0 || index >= sz) {
+            throw new NoSuchElementException(
+                String.format("The specified index (%1$d) is outside the available range [0, %2$d)",
+                    Integer.valueOf(index), Integer.valueOf(sz)));
+        }
+
+        final int idx = (start + index) % maxElements;
+        return elements[idx];
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Adds the given element to this queue. If the queue is full, the least recently added
+     * element is discarded so that a new element can be inserted.
+     *
+     * @param element  the element to add
+     * @return true, always
+     * @throws NullPointerException  if the given element is null
+     */
+    @Override
+    public boolean offer(E element) {
+        return add(element);
+    }
+
+    @Override
+    public E poll() {
+        if (isEmpty()) {
+            return null;
+        }
+        return remove();
+    }
+
+    @Override
+    public E element() {
+        if (isEmpty()) {
+            throw new NoSuchElementException("queue is empty");
+        }
+        return peek();
+    }
+
+    @Override
+    public E peek() {
+        if (isEmpty()) {
+            return null;
+        }
+        return elements[start];
+    }
+
+    @Override
+    public E remove() {
+        if (isEmpty()) {
+            throw new NoSuchElementException("queue is empty");
+        }
+
+        final E element = elements[start];
+        if (null != element) {
+            elements[start++] = null;
+
+            if (start >= maxElements) {
+                start = 0;
+            }
+            full = false;
+        }
+        return element;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Increments the internal index.
+     *
+     * @param index  the index to increment
+     * @return the updated index
+     */
+    private int increment(int index) {
+        index++;
+        if (index >= maxElements) {
+            index = 0;
+        }
+        return index;
+    }
+
+    /**
+     * Decrements the internal index.
+     *
+     * @param index  the index to decrement
+     * @return the updated index
+     */
+    private int decrement(int index) {
+        index--;
+        if (index < 0) {
+            index = maxElements - 1;
+        }
+        return index;
+    }
+
+    /**
+     * Returns an iterator over this queue's elements.
+     *
+     * @return an iterator over this queue's elements
+     */
+    @Override
+    public Iterator<E> iterator() {
+        return new Iterator<E>() {
+
+            private int index = start;
+            private int lastReturnedIndex = -1;
+            private boolean isFirst = full;
+
+            @Override
+            public boolean hasNext() {
+                return isFirst || index != end;
+            }
+
+            @Override
+            public E next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                isFirst = false;
+                lastReturnedIndex = index;
+                index = increment(index);
+                return elements[lastReturnedIndex];
+            }
+
+            @Override
+            public void remove() {
+                if (lastReturnedIndex == -1) {
+                    throw new IllegalStateException();
+                }
+
+                // First element can be removed quickly
+                if (lastReturnedIndex == start) {
+                    CircularFifoQueue.this.remove();
+                    lastReturnedIndex = -1;
+                    return;
+                }
+
+                int pos = lastReturnedIndex + 1;
+                if (start < lastReturnedIndex && pos < end) {
+                    // shift in one part
+                    System.arraycopy(elements, pos, elements, lastReturnedIndex, end - pos);
+                } else {
+                    // Other elements require us to shift the subsequent elements
+                    while (pos != end) {
+                        if (pos >= maxElements) {
+                            elements[pos - 1] = elements[0];
+                            pos = 0;
+                        } else {
+                            elements[decrement(pos)] = elements[pos];
+                            pos = increment(pos);
+                        }
+                    }
+                }
+
+                lastReturnedIndex = -1;
+                end = decrement(end);
+                elements[end] = null;
+                full = false;
+                index = decrement(index);
+            }
+
+        };
+    }
+
+}

--- a/raven/src/test/java/com/getsentry/raven/RavenContextTest.java
+++ b/raven/src/test/java/com/getsentry/raven/RavenContextTest.java
@@ -1,0 +1,89 @@
+package com.getsentry.raven;
+
+import com.getsentry.raven.event.Breadcrumb;
+import com.getsentry.raven.event.BreadcrumbBuilder;
+import org.hamcrest.Matchers;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RavenContextTest {
+
+    @Test
+    public void testActivateDeactivate() {
+        RavenContext context = new RavenContext();
+
+        assertThat(RavenContext.getActiveContexts(), emptyCollectionOf(RavenContext.class));
+
+        context.activate();
+
+        List<RavenContext> match = new ArrayList<>(1);
+        match.add(context);
+        assertThat(RavenContext.getActiveContexts(), equalTo(match));
+
+        context.deactivate();
+
+        assertThat(RavenContext.getActiveContexts(), emptyCollectionOf(RavenContext.class));
+    }
+
+    @Test
+    public void testBreadcrumbs() {
+        RavenContext context = new RavenContext();
+
+        Breadcrumb breadcrumb = new BreadcrumbBuilder()
+            .setLevel("info")
+            .setCategory("foo")
+            .setMessage("test")
+            .build();
+        context.recordBreadcrumb(breadcrumb);
+
+        List<Breadcrumb> breadcrumbMatch = new ArrayList<>();
+        breadcrumbMatch.add(breadcrumb);
+
+        List<Breadcrumb> breadcrumbs = new ArrayList<>();
+        Iterator<Breadcrumb> iter = context.getBreadcrumbs();
+        while (iter.hasNext()) {
+            breadcrumbs.add(iter.next());
+        }
+
+        assertThat(breadcrumbs, equalTo(breadcrumbMatch));
+    }
+
+    @Test
+    public void breadcrumbLimit() {
+        RavenContext context = new RavenContext(1);
+
+        Breadcrumb breadcrumb1 = new BreadcrumbBuilder()
+            .setLevel("info")
+            .setCategory("foo")
+            .setMessage("test1")
+            .build();
+        Breadcrumb breadcrumb2 = new BreadcrumbBuilder()
+            .setLevel("info")
+            .setCategory("foo")
+            .setMessage("test2")
+            .build();
+
+        context.recordBreadcrumb(breadcrumb1);
+        context.recordBreadcrumb(breadcrumb2);
+
+        List<Breadcrumb> breadcrumbMatch = new ArrayList<>();
+        breadcrumbMatch.add(breadcrumb2);
+
+        List<Breadcrumb> breadcrumbs = new ArrayList<>();
+        Iterator<Breadcrumb> iter = context.getBreadcrumbs();
+        while (iter.hasNext()) {
+            breadcrumbs.add(iter.next());
+        }
+
+        assertThat(breadcrumbs, equalTo(breadcrumbMatch));
+
+    }
+
+}

--- a/raven/src/test/java/com/getsentry/raven/marshaller/json/JsonMarshallerTest.java
+++ b/raven/src/test/java/com/getsentry/raven/marshaller/json/JsonMarshallerTest.java
@@ -1,6 +1,8 @@
 package com.getsentry.raven.marshaller.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.getsentry.raven.event.Breadcrumb;
+import com.getsentry.raven.event.BreadcrumbBuilder;
 import mockit.*;
 import com.getsentry.raven.event.Event;
 import com.getsentry.raven.event.interfaces.SentryInterface;
@@ -10,9 +12,11 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import static com.getsentry.raven.marshaller.json.JsonComparisonUtil.*;
@@ -201,6 +205,37 @@ public class JsonMarshallerTest {
         jsonMarshaller.marshall(mockEvent, jsonOutputStreamParser.outputStream());
 
         assertThat(jsonOutputStreamParser.value(), is(jsonResource("/com/getsentry/raven/marshaller/json/jsonmarshallertest/testRelease.json")));
+    }
+
+    @Test
+    public void testEventBreadcrumbsWrittenProperly() throws Exception {
+        final JsonOutputStreamParser jsonOutputStreamParser = newJsonOutputStream();
+
+        Breadcrumb breadcrumb1 = new BreadcrumbBuilder()
+            .setTimestamp(new Date(1463169342000L))
+            .setLevel("info")
+            .setCategory("foo")
+            .setMessage("test1")
+            .build();
+        Breadcrumb breadcrumb2 = new BreadcrumbBuilder()
+            .setTimestamp(new Date(1463169343000L))
+            .setLevel("info")
+            .setCategory("foo")
+            .setMessage("test2")
+            .build();
+
+        final List<Breadcrumb> breadcrumbs = new ArrayList<>();
+        breadcrumbs.add(breadcrumb1);
+        breadcrumbs.add(breadcrumb2);
+
+        new NonStrictExpectations() {{
+            mockEvent.getBreadcrumbs();
+            result = breadcrumbs;
+        }};
+
+        jsonMarshaller.marshall(mockEvent, jsonOutputStreamParser.outputStream());
+
+        assertThat(jsonOutputStreamParser.value(), is(jsonResource("/com/getsentry/raven/marshaller/json/jsonmarshallertest/testBreadcrumbs.json")));
     }
 
     @Test

--- a/raven/src/test/resources/com/getsentry/raven/marshaller/json/jsonmarshallertest/testBreadcrumbs.json
+++ b/raven/src/test/resources/com/getsentry/raven/marshaller/json/jsonmarshallertest/testBreadcrumbs.json
@@ -1,0 +1,20 @@
+{
+    "event_id": "00000000000000000000000000000000",
+    "message": null,
+    "timestamp": "1970-01-01T00:00:00",
+    "level": null,
+    "logger": null,
+    "platform": null,
+    "culprit": null,
+    "tags": {},
+    "server_name": null,
+    "release": null,
+    "extra": {},
+    "checksum": null,
+    "breadcrumbs": {
+        "values": [
+            {"timestamp":1463169342,"level":"info","message":"test1","category":"foo"},
+            {"timestamp":1463169343,"level":"info","message":"test2","category":"foo"}
+        ]
+    }
+}

--- a/src/checkstyle/suppressions.xml
+++ b/src/checkstyle/suppressions.xml
@@ -6,4 +6,5 @@
 <suppressions>
     <suppress files="com/getsentry/raven/sentrystub/.*" checks=".*"/>
     <suppress files="com/getsentry/raven/util/Base64.*" checks=".*"/>
+    <suppress files="com/getsentry/raven/util/CircularFifoQueue\.java" checks=".*"/>
 </suppressions>


### PR DESCRIPTION
Definitely still need to add tests.

Also, this is just the "backend" implementation right now. It all works but you have to build your own `Event`:

```java
        Raven raven = DefaultRavenFactory.ravenInstance();

        Breadcrumb b1 = new BreadcrumbBuilder()
            .setMessage("Breadcrumb 1")
            .setLevel("info")
            .setCategory("category")
            .build();
        Breadcrumb b2 = new BreadcrumbBuilder()
            .setMessage("Breadcrumb 2")
            .setLevel("warning")
            .setCategory("category")
            .build();

        List<Breadcrumb> breadcrumbs = new ArrayList<Breadcrumb>();
        breadcrumbs.add(b1);
        breadcrumbs.add(b2);

        Event event = new EventBuilder()
            .withMessage("Hello, world.")
            .withBreadcrumbs(breadcrumbs)
            .build();

        raven.sendEvent(event);
```
So my question now is... how are we handling these in other language loggers? It seems like they'd have to configure a second level (for capturing breadcrumbs) so that they could do something like "send error and above to Sentry, but capture warn and above as Breadcrumbs"?