### PR TITLE
Remove Logback `minLevel` default parameter value.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 7.2.3
 -------------
 
 - Accept `Throwable` instances as parameter to `Raven.sendException`.
+- Remove default `WARNING` filter level for the Logback appender.
 
 Version 7.2.2
 -------------

--- a/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
@@ -73,9 +73,11 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      */
     protected String serverName;
     /**
-     * If set, only events with level = minLevel and up will be recorded.
+     * If set, only events with level = minLevel and up will be recorded. (This
+     * configuration parameter is deprecated in favor of using Logback
+     * Filters.)
      */
-    protected Level minLevel = Level.WARN;
+    protected Level minLevel;
     /**
      * Additional tags to be sent to sentry.
      * <p>
@@ -325,7 +327,7 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
     }
 
     public void setMinLevel(String minLevel) {
-        this.minLevel = Level.toLevel(minLevel, Level.WARN);
+        this.minLevel = minLevel != null ? Level.toLevel(minLevel) : null;
     }
 
     /**

--- a/raven-logback/src/test/java/com/getsentry/raven/logback/SentryAppenderEventLevelFilterTest.java
+++ b/raven-logback/src/test/java/com/getsentry/raven/logback/SentryAppenderEventLevelFilterTest.java
@@ -39,8 +39,8 @@ public class SentryAppenderEventLevelFilterTest {
                 {"WARN", 2},
                 {"ERROR", 1},
                 {"error", 1},
-                {"xxx", 2},
-                {null, 2}};
+                {"xxx", 4},  // invalid level will be coerced to DEBUG
+                {null, 5}};
     }
 
     @Test(dataProvider = "levels")
@@ -69,8 +69,8 @@ public class SentryAppenderEventLevelFilterTest {
 
         new Verifications() {{
             mockRaven.sendEvent((Event) any);
-            minTimes = 2;
-            maxTimes = 2;
+            minTimes = 5;
+            maxTimes = 5;
         }};
     }
 


### PR DESCRIPTION
This removes the default level filter that was deprecated in f5ad3dcdf8e77dcee117487e233b51ffe1bc0219, since Logback filters should be used instead of duplicating this functionality.

Fixes GH-206.

@getsentry/java 