### PR TITLE
Add `raven.async.shutdowntimeout` option.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 7.2.3
 -------------
 
 - Accept `Throwable` instances as parameter to `Raven.sendException`.
+- Add `raven.async.shutdowntimeout` option.
 
 Version 7.2.2
 -------------

--- a/README.md
+++ b/README.md
@@ -151,9 +151,14 @@ To disable the async mode, add `raven.async=false` to the DSN:
 
 #### Graceful Shutdown (advanced)
 In order to shutdown the asynchronous connection gracefully, a `ShutdownHook`
-is created.
-This could lead to memory leaks in an environment where the life cycle of
-Raven doesn't match the life cycle of the JVM.
+is created. By default, the asynchronous connection is given 1 second
+to shutdown gracefully, but this can be adjusted via
+`raven.async.shutdowntimeout` (represented in milliseconds):
+
+    http://public:private@host:port/1?raven.async.shutdowntimeout=5000
+
+The `ShutdownHook` could lead to memory leaks in an environment where
+the life cycle of Raven doesn't match the life cycle of the JVM.
 
 An example would be in a JEE environment where the application using Raven
 could be deployed and undeployed regularly.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ to shutdown gracefully, but this can be adjusted via
 
     http://public:private@host:port/1?raven.async.shutdowntimeout=5000
 
+The special value `-1` can be used to disable the timeout and wait
+indefinitely for the executor to terminate.
+
 The `ShutdownHook` could lead to memory leaks in an environment where
 the life cycle of Raven doesn't match the life cycle of the JVM.
 

--- a/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
@@ -57,7 +57,7 @@ public class DefaultRavenFactory extends RavenFactory {
     /**
      * Option for the graceful shutdown timeout of the async executor, in milliseconds.
      */
-    public static final String SHUTDOWN_TIMEOUT = "raven.async.shutdowntimeout";
+    public static final String SHUTDOWN_TIMEOUT_OPTION = "raven.async.shutdowntimeout";
     /**
      * Option to hide common stackframes with enclosing exceptions.
      */
@@ -150,7 +150,7 @@ public class DefaultRavenFactory extends RavenFactory {
 
         boolean gracefulShutdown = !FALSE.equalsIgnoreCase(dsn.getOptions().get(GRACEFUL_SHUTDOWN_OPTION));
 
-        String shutdownTimeoutStr = dsn.getOptions().get(SHUTDOWN_TIMEOUT);
+        String shutdownTimeoutStr = dsn.getOptions().get(SHUTDOWN_TIMEOUT_OPTION);
         if (shutdownTimeoutStr != null) {
             long shutdownTimeout = Long.parseLong(shutdownTimeoutStr);
             return new AsyncConnection(connection, executorService, gracefulShutdown, shutdownTimeout);

--- a/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
@@ -55,6 +55,10 @@ public class DefaultRavenFactory extends RavenFactory {
      */
     public static final String QUEUE_SIZE_OPTION = "raven.async.queuesize";
     /**
+     * Option for the graceful shutdown timeout of the async executor, in milliseconds.
+     */
+    public static final String SHUTDOWN_TIMEOUT = "raven.async.shutdowntimeout";
+    /**
      * Option to hide common stackframes with enclosing exceptions.
      */
     public static final String HIDE_COMMON_FRAMES_OPTION = "raven.stacktrace.hidecommon";
@@ -146,7 +150,13 @@ public class DefaultRavenFactory extends RavenFactory {
 
         boolean gracefulShutdown = !FALSE.equalsIgnoreCase(dsn.getOptions().get(GRACEFUL_SHUTDOWN_OPTION));
 
-        return new AsyncConnection(connection, executorService, gracefulShutdown);
+        String shutdownTimeoutStr = dsn.getOptions().get(SHUTDOWN_TIMEOUT);
+        if (shutdownTimeoutStr != null) {
+            long shutdownTimeout = Long.parseLong(shutdownTimeoutStr);
+            return new AsyncConnection(connection, executorService, gracefulShutdown, shutdownTimeout);
+        } else {
+            return new AsyncConnection(connection, executorService, gracefulShutdown);
+        }
     }
 
     /**

--- a/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
@@ -126,6 +126,7 @@ public class AsyncConnection implements Connection {
      *
      * @see #close()
      */
+    @SuppressWarnings("checkstyle:magicnumber")
     private void doClose() throws IOException {
         logger.info("Gracefully shutdown sentry threads.");
         closed = true;

--- a/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
@@ -20,9 +20,13 @@ import java.util.concurrent.TimeUnit;
 public class AsyncConnection implements Connection {
     private static final Logger logger = LoggerFactory.getLogger(AsyncConnection.class);
     /**
-     * Timeout of the {@link #executorService}.
+     * Default timeout of the {@link #executorService}, in milliseconds.
      */
-    private static final long SHUTDOWN_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
+    private static final long DEFAULT_SHUTDOWN_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
+    /**
+     * Timeout of the {@link #executorService}, in milliseconds.
+     */
+    private final long shutdownTimeout;
     /**
      * Connection used to actually send the events.
      */
@@ -53,8 +57,10 @@ public class AsyncConnection implements Connection {
      * @param executorService  executorService used to process events, if null, the executorService will automatically
      *                         be set to {@code Executors.newSingleThreadExecutor()}
      * @param gracefulShutdown Indicates whether or not the shutdown operation should be managed by a ShutdownHook.
+     * @param shutdownTimeout  timeout for graceful shutdown of the executor, in milliseconds.
      */
-    public AsyncConnection(Connection actualConnection, ExecutorService executorService, boolean gracefulShutdown) {
+    public AsyncConnection(Connection actualConnection, ExecutorService executorService, boolean gracefulShutdown,
+        long shutdownTimeout) {
         this.actualConnection = actualConnection;
         if (executorService == null)
             this.executorService = Executors.newSingleThreadExecutor();
@@ -64,6 +70,21 @@ public class AsyncConnection implements Connection {
             this.gracefulShutdown = gracefulShutdown;
             addShutdownHook();
         }
+        this.shutdownTimeout = shutdownTimeout;
+    }
+
+    /**
+     * Creates a connection which will rely on an executor to send events.
+     * <p>
+     * Will propagate the {@link #close()} operation.
+     *
+     * @param actualConnection connection used to send the events.
+     * @param executorService  executorService used to process events, if null, the executorService will automatically
+     *                         be set to {@code Executors.newSingleThreadExecutor()}
+     * @param gracefulShutdown Indicates whether or not the shutdown operation should be managed by a ShutdownHook.
+     */
+    public AsyncConnection(Connection actualConnection, ExecutorService executorService, boolean gracefulShutdown) {
+        this(actualConnection, executorService, gracefulShutdown, DEFAULT_SHUTDOWN_TIMEOUT);
     }
 
     /**
@@ -89,7 +110,7 @@ public class AsyncConnection implements Connection {
      * {@inheritDoc}.
      * <p>
      * Closing the {@link AsyncConnection} will attempt a graceful shutdown of the {@link #executorService} with a
-     * timeout of {@link #SHUTDOWN_TIMEOUT}, allowing the current events to be submitted while new events will
+     * timeout of {@link #shutdownTimeout}, allowing the current events to be submitted while new events will
      * be rejected.<br>
      * If the shutdown times out, the {@code executorService} will be forced to shutdown.
      */
@@ -110,7 +131,7 @@ public class AsyncConnection implements Connection {
         closed = true;
         executorService.shutdown();
         try {
-            if (!executorService.awaitTermination(SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS)) {
+            if (!executorService.awaitTermination(shutdownTimeout, TimeUnit.MILLISECONDS)) {
                 logger.warn("Graceful shutdown took too much time, forcing the shutdown.");
                 List<Runnable> tasks = executorService.shutdownNow();
                 logger.info("{} tasks failed to execute before the shutdown.", tasks.size());


### PR DESCRIPTION
#209 

Quick addition. I'm not in love with adding another constructor to `AsyncConnection` but it felt like the safest way to prevent breakage (and make this optional) for anyone that is already doing something custom there.