### PR TITLE
Add formatted field to JSON if possible.

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/event/interfaces/MessageInterface.java
+++ b/raven/src/main/java/com/getsentry/raven/event/interfaces/MessageInterface.java
@@ -29,6 +29,7 @@ public class MessageInterface implements SentryInterface {
     public static final String MESSAGE_INTERFACE = "sentry.interfaces.Message";
     private final String message;
     private final List<String> parameters;
+    private final String formatted;
 
     /**
      * Creates a non parametrised message.
@@ -63,6 +64,13 @@ public class MessageInterface implements SentryInterface {
     public MessageInterface(String message, List<String> parameters) {
         this.message = message;
         this.parameters = Collections.unmodifiableList(new ArrayList<>(parameters));
+        String fmt;
+        try {
+            fmt = String.format(message, parameters.toArray());
+        } catch (Exception e) {
+            fmt = null;
+        }
+        this.formatted = fmt;
     }
 
     @Override
@@ -76,6 +84,10 @@ public class MessageInterface implements SentryInterface {
 
     public List<String> getParameters() {
         return parameters;
+    }
+
+    public String getFormatted() {
+        return formatted;
     }
 
     @Override

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/MessageInterfaceBinding.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/MessageInterfaceBinding.java
@@ -15,6 +15,7 @@ public class MessageInterfaceBinding implements InterfaceBinding<MessageInterfac
     public static final int MAX_MESSAGE_LENGTH = 1000;
     private static final String MESSAGE_PARAMETER = "message";
     private static final String PARAMS_PARAMETER = "params";
+    private static final String FORMATTED_PARAMETER = "formatted";
 
     /**
      * Formats a message, ensuring that the maximum length {@link #MAX_MESSAGE_LENGTH} isn't reached.
@@ -39,6 +40,9 @@ public class MessageInterfaceBinding implements InterfaceBinding<MessageInterfac
             generator.writeString(parameter);
         }
         generator.writeEndArray();
+        if (messageInterface.getFormatted() != null) {
+            generator.writeStringField(FORMATTED_PARAMETER, formatMessage(messageInterface.getFormatted()));
+        }
         generator.writeEndObject();
     }
 }

--- a/raven/src/test/java/com/getsentry/raven/event/interfaces/MessageInterfaceTest.java
+++ b/raven/src/test/java/com/getsentry/raven/event/interfaces/MessageInterfaceTest.java
@@ -23,8 +23,9 @@ public class MessageInterfaceTest {
 
     @Test
     public void testListParameters() throws Exception {
-        final String message = "b88145c2-8c46-49fc-81cc-8982f288e5c2";
+        final String message = "b88145c2-8c46-49fc-81cc-8982f288e5c2 %s";
         final List<String> parameters = Collections.singletonList("e703048a-0084-4306-a04e-04eaca572046");
+        final String formatted = "b88145c2-8c46-49fc-81cc-8982f288e5c2 e703048a-0084-4306-a04e-04eaca572046";
 
         final MessageInterface messageInterface = new MessageInterface(message, parameters);
 
@@ -35,7 +36,35 @@ public class MessageInterfaceTest {
 
     @Test
     public void testVarargsParameters() throws Exception {
+        final String message = "b3b31d87-de49-47fb-8f83-e3be45e7a611 %s";
+        final String parameter = "9113953f-3306-4aeb-8d3a-319b1ea83683";
+        final String formatted = "b3b31d87-de49-47fb-8f83-e3be45e7a611 9113953f-3306-4aeb-8d3a-319b1ea83683";
+
+        final MessageInterface messageInterface = new MessageInterface(message, parameter);
+
+        assertThat(messageInterface.getMessage(), is(message));
+        assertThat(messageInterface.getParameters(), equalTo(Collections.singletonList(parameter)));
+        assertThat(messageInterface.getInterfaceName(), is(MessageInterface.MESSAGE_INTERFACE));
+        assertThat(messageInterface.getFormatted(), is(formatted));
+    }
+
+    @Test
+    public void notEnoughParametersOK() {
         final String message = "b3b31d87-de49-47fb-8f83-e3be45e7a611";
+        final String parameter = "9113953f-3306-4aeb-8d3a-319b1ea83683";
+        final String formatted = "b3b31d87-de49-47fb-8f83-e3be45e7a611";
+
+        final MessageInterface messageInterface = new MessageInterface(message, parameter);
+
+        assertThat(messageInterface.getMessage(), is(message));
+        assertThat(messageInterface.getParameters(), equalTo(Collections.singletonList(parameter)));
+        assertThat(messageInterface.getInterfaceName(), is(MessageInterface.MESSAGE_INTERFACE));
+        assertThat(messageInterface.getFormatted(), is(formatted));
+    }
+
+    @Test
+    public void tooManyParametersOK() {
+        final String message = "b3b31d87-de49-47fb-8f83-e3be45e7a611 %s %s";
         final String parameter = "9113953f-3306-4aeb-8d3a-319b1ea83683";
 
         final MessageInterface messageInterface = new MessageInterface(message, parameter);
@@ -43,5 +72,7 @@ public class MessageInterfaceTest {
         assertThat(messageInterface.getMessage(), is(message));
         assertThat(messageInterface.getParameters(), equalTo(Collections.singletonList(parameter)));
         assertThat(messageInterface.getInterfaceName(), is(MessageInterface.MESSAGE_INTERFACE));
+        assertThat(messageInterface.getFormatted(), isEmptyOrNullString());
     }
+
 }

--- a/raven/src/test/java/com/getsentry/raven/marshaller/json/MessageInterfaceBindingTest.java
+++ b/raven/src/test/java/com/getsentry/raven/marshaller/json/MessageInterfaceBindingTest.java
@@ -22,18 +22,44 @@ public class MessageInterfaceBindingTest {
     @Test
     public void testSimpleMessage() throws Exception {
         final JsonGeneratorParser jsonGeneratorParser = newJsonGenerator();
-        final String message = "550ee459-cbb5-438e-91d2-b0bbdefab670";
+        final String message = "%s 550ee459-cbb5-438e-91d2-b0bbdefab670 %s";
         final List<String> parameters = Arrays.asList("33ed929b-d803-46b6-a57b-9c0feab1f468",
                 "5fc10379-6392-470d-9de5-e4cb805ab78c");
+        final String formatted = "33ed929b-d803-46b6-a57b-9c0feab1f468"
+            + " 550ee459-cbb5-438e-91d2-b0bbdefab670"
+            + " 5fc10379-6392-470d-9de5-e4cb805ab78c";
         new NonStrictExpectations() {{
             mockMessageInterface.getMessage();
             result = message;
             mockMessageInterface.getParameters();
             result = parameters;
+            mockMessageInterface.getFormatted();
+            result = formatted;
         }};
 
         interfaceBinding.writeInterface(jsonGeneratorParser.generator(), mockMessageInterface);
 
         assertThat(jsonGeneratorParser.value(), is(jsonResource("/com/getsentry/raven/marshaller/json/Message1.json")));
     }
+
+    @Test
+    public void formattedNotIncludedWhenInvalid() throws Exception {
+        final JsonGeneratorParser jsonGeneratorParser = newJsonGenerator();
+        final String message = "550ee459-cbb5-438e-91d2-b0bbdefab670 %s %s";
+        final List<String> parameters = Arrays.asList("33ed929b-d803-46b6-a57b-9c0feab1f468");
+
+        new NonStrictExpectations() {{
+            mockMessageInterface.getMessage();
+            result = message;
+            mockMessageInterface.getParameters();
+            result = parameters;
+            mockMessageInterface.getFormatted();
+            result = null;
+        }};
+
+        interfaceBinding.writeInterface(jsonGeneratorParser.generator(), mockMessageInterface);
+
+        assertThat(jsonGeneratorParser.value(), is(jsonResource("/com/getsentry/raven/marshaller/json/Message2.json")));
+    }
+
 }

--- a/raven/src/test/resources/com/getsentry/raven/marshaller/json/Message1.json
+++ b/raven/src/test/resources/com/getsentry/raven/marshaller/json/Message1.json
@@ -1,4 +1,5 @@
 {
-    "message": "550ee459-cbb5-438e-91d2-b0bbdefab670",
-    "params": ["33ed929b-d803-46b6-a57b-9c0feab1f468", "5fc10379-6392-470d-9de5-e4cb805ab78c"]
+    "message": "%s 550ee459-cbb5-438e-91d2-b0bbdefab670 %s",
+    "params": ["33ed929b-d803-46b6-a57b-9c0feab1f468", "5fc10379-6392-470d-9de5-e4cb805ab78c"],
+    "formatted": "33ed929b-d803-46b6-a57b-9c0feab1f468 550ee459-cbb5-438e-91d2-b0bbdefab670 5fc10379-6392-470d-9de5-e4cb805ab78c"
 }

--- a/raven/src/test/resources/com/getsentry/raven/marshaller/json/Message2.json
+++ b/raven/src/test/resources/com/getsentry/raven/marshaller/json/Message2.json
@@ -1,0 +1,4 @@
+{
+  "message": "550ee459-cbb5-438e-91d2-b0bbdefab670 %s %s",
+  "params": ["33ed929b-d803-46b6-a57b-9c0feab1f468"]
+}


### PR DESCRIPTION
I used `String.format` which expects args like `%s` ... I haven't given this a lot of thought. Some (all?) logging frameworks use `{}` in Java.

If anything this is the scaffolding and we just have to decide which formatting to support?