### PR TITLE
Add formatted field to JSON if possible.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 7.4.0
 -------------
 
 - Changed default ``raven.async.queuesize`` from unlimited to 50.
+- Add ``formatted`` field to JSON payload if possible.
 
 Version 7.3.0
 -------------

--- a/CHANGES
+++ b/CHANGES
@@ -3,12 +3,12 @@ Version 7.5.0
 
 - Add support for configuring an HTTP proxy in the DSN.
 - Add more debugging information to ``RavenFactory.ravenInstance``.
+- Add ``formatted`` field to JSON payload if possible.
 
 Version 7.4.0
 -------------
 
 - Changed default ``raven.async.queuesize`` from unlimited to 50.
-- Add ``formatted`` field to JSON payload if possible.
 - Add callback system for exceptions raised while attempting to send events.
 
 Version 7.3.0

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -260,8 +260,10 @@ public class SentryAppender extends AbstractAppender {
         }
 
         if (!eventMessage.getFormattedMessage().equals(eventMessage.getFormat())) {
-            eventBuilder.withSentryInterface(new MessageInterface(eventMessage.getFormat(),
-                    formatMessageParameters(eventMessage.getParameters())));
+            eventBuilder.withSentryInterface(new MessageInterface(
+                eventMessage.getFormat(),
+                formatMessageParameters(eventMessage.getParameters()),
+                eventMessage.getFormattedMessage()));
         }
 
         Throwable throwable = event.getThrown();

--- a/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
@@ -208,8 +208,10 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         }
 
         if (iLoggingEvent.getArgumentArray() != null) {
-            eventBuilder.withSentryInterface(new MessageInterface(iLoggingEvent.getMessage(),
-                    formatMessageParameters(iLoggingEvent.getArgumentArray())));
+            eventBuilder.withSentryInterface(new MessageInterface(
+                iLoggingEvent.getMessage(),
+                formatMessageParameters(iLoggingEvent.getArgumentArray()),
+                iLoggingEvent.getFormattedMessage()));
         }
 
         if (iLoggingEvent.getThrowableProxy() != null) {

--- a/raven/src/main/java/com/getsentry/raven/event/interfaces/MessageInterface.java
+++ b/raven/src/main/java/com/getsentry/raven/event/interfaces/MessageInterface.java
@@ -1,9 +1,11 @@
 package com.getsentry.raven.event.interfaces;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The Message interface for Sentry allows to send the original pattern to Sentry, allowing the events to be grouped
@@ -29,6 +31,7 @@ public class MessageInterface implements SentryInterface {
     public static final String MESSAGE_INTERFACE = "sentry.interfaces.Message";
     private final String message;
     private final List<String> parameters;
+    @Nullable private final String formatted;
 
     /**
      * Creates a non parametrised message.
@@ -61,8 +64,20 @@ public class MessageInterface implements SentryInterface {
      * @param parameters parameters of the message.
      */
     public MessageInterface(String message, List<String> parameters) {
+        this(message, parameters, null);
+    }
+
+    /**
+     * Creates a parametrised message for an {@link com.getsentry.raven.event.Event}.
+     *
+     * @param message    original message.
+     * @param parameters parameters of the message.
+     * @param formatted  message formatted with parameters
+     */
+    public MessageInterface(String message, List<String> parameters, String formatted) {
         this.message = message;
         this.parameters = Collections.unmodifiableList(new ArrayList<>(parameters));
+        this.formatted = formatted;
     }
 
     @Override
@@ -78,26 +93,35 @@ public class MessageInterface implements SentryInterface {
         return parameters;
     }
 
+    public String getFormatted() {
+        return formatted;
+    }
+
     @Override
     public String toString() {
         return "MessageInterface{"
-                + "message='" + message + '\''
-                + ", parameters=" + parameters
-                + '}';
+            + "message='" + message + '\''
+            + ", parameters=" + parameters
+            + ", formatted=" + formatted
+            + '}';
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         MessageInterface that = (MessageInterface) o;
-
-        return message.equals(that.message) && parameters.equals(that.parameters);
+        return Objects.equals(message, that.message)
+            && Objects.equals(parameters, that.parameters)
+            && Objects.equals(formatted, that.formatted);
     }
 
     @Override
     public int hashCode() {
-        return message.hashCode();
+        return Objects.hash(message, parameters, formatted);
     }
 }

--- a/raven/src/main/java/com/getsentry/raven/event/interfaces/MessageInterface.java
+++ b/raven/src/main/java/com/getsentry/raven/event/interfaces/MessageInterface.java
@@ -40,9 +40,7 @@ public class MessageInterface implements SentryInterface {
      * recommended to use {@link com.getsentry.raven.event.EventBuilder#withMessage(String)} instead.
      *
      * @param message message to add to the event.
-     * @deprecated Use {@link com.getsentry.raven.event.EventBuilder#withMessage(String)} instead.
      */
-    @Deprecated
     public MessageInterface(String message) {
         this(message, Collections.<String>emptyList());
     }

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -220,18 +220,20 @@ public class SentryHandler extends Handler {
             message = record.getResourceBundle().getString(record.getMessage());
         }
 
+        String topLevelMessage = message;
         if (record.getParameters() != null) {
             String formatted;
             List<String> parameters = formatMessageParameters(record.getParameters());
             try {
                 formatted = formatMessage(message, record.getParameters());
+                topLevelMessage = formatted; // write out formatted as Event's message key
             } catch (Exception e) {
                 // local formatting failed, send message and parameters without formatted string
                 formatted = null;
             }
             eventBuilder.withSentryInterface(new MessageInterface(message, parameters, formatted));
         }
-        eventBuilder.withMessage(message);
+        eventBuilder.withMessage(topLevelMessage);
 
         Throwable throwable = record.getThrown();
         if (throwable != null)

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -221,7 +221,9 @@ public class SentryHandler extends Handler {
         }
 
         String topLevelMessage = message;
-        if (record.getParameters() != null) {
+        if (record.getParameters() == null) {
+            eventBuilder.withSentryInterface(new MessageInterface(message));
+        } else {
             String formatted;
             List<String> parameters = formatMessageParameters(record.getParameters());
             try {

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -220,21 +220,23 @@ public class SentryHandler extends Handler {
         if (record.getResourceBundle() != null && record.getResourceBundle().containsKey(record.getMessage())) {
             message = record.getResourceBundle().getString(record.getMessage());
         }
+
+        String formatted = message; // default to plain message
         if (record.getParameters() != null) {
             List<String> parameters = formatMessageParameters(record.getParameters());
-            eventBuilder.withSentryInterface(new MessageInterface(message, parameters));
             if (printfStyle) {
                 try {
-                    message = String.format(message, record.getParameters());
+                    formatted = String.format(message, record.getParameters());
                 } catch (MissingFormatArgumentException e) {
                     // use unformatted message
-                    message = record.getMessage();
+                    formatted = message;
                 }
             } else {
-                message = MessageFormat.format(message, record.getParameters());
+                formatted = MessageFormat.format(message, record.getParameters());
             }
+            eventBuilder.withSentryInterface(new MessageInterface(message, parameters, formatted));
         }
-        eventBuilder.withMessage(message);
+        eventBuilder.withMessage(formatted);
 
         Throwable throwable = record.getThrown();
         if (throwable != null)

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -128,7 +128,7 @@ public class JsonMarshaller implements Marshaller {
         generator.writeStartObject();
 
         generator.writeStringField(EVENT_ID, formatId(event.getId()));
-        generator.writeStringField(MESSAGE, formatMessage(event.getMessage()));
+        generator.writeStringField(MESSAGE, trimMessage(event.getMessage()));
         generator.writeStringField(TIMESTAMP, ISO_FORMAT.get().format(event.getTimestamp()));
         generator.writeStringField(LEVEL, formatLevel(event.getLevel()));
         generator.writeStringField(LOGGER, event.getLogger());
@@ -268,12 +268,12 @@ public class JsonMarshaller implements Marshaller {
     }
 
     /**
-     * Formats a message, ensuring that the maximum length {@link #MAX_MESSAGE_LENGTH} isn't reached.
+     * Trims a message, ensuring that the maximum length {@link #MAX_MESSAGE_LENGTH} isn't reached.
      *
      * @param message message to format.
-     * @return formatted message (shortened if necessary).
+     * @return trimmed message (shortened if necessary).
      */
-    private String formatMessage(String message) {
+    private String trimMessage(String message) {
         if (message == null)
             return null;
         else if (message.length() > MAX_MESSAGE_LENGTH)

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/MessageInterfaceBinding.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/MessageInterfaceBinding.java
@@ -15,6 +15,7 @@ public class MessageInterfaceBinding implements InterfaceBinding<MessageInterfac
     public static final int MAX_MESSAGE_LENGTH = 1000;
     private static final String MESSAGE_PARAMETER = "message";
     private static final String PARAMS_PARAMETER = "params";
+    private static final String FORMATTED_PARAMETER = "formatted";
 
     /**
      * Formats a message, ensuring that the maximum length {@link #MAX_MESSAGE_LENGTH} isn't reached.
@@ -39,6 +40,9 @@ public class MessageInterfaceBinding implements InterfaceBinding<MessageInterfac
             generator.writeString(parameter);
         }
         generator.writeEndArray();
+        if (messageInterface.getFormatted() != null) {
+            generator.writeStringField(FORMATTED_PARAMETER, formatMessage(messageInterface.getFormatted()));
+        }
         generator.writeEndObject();
     }
 }

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/MessageInterfaceBinding.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/MessageInterfaceBinding.java
@@ -18,12 +18,12 @@ public class MessageInterfaceBinding implements InterfaceBinding<MessageInterfac
     private static final String FORMATTED_PARAMETER = "formatted";
 
     /**
-     * Formats a message, ensuring that the maximum length {@link #MAX_MESSAGE_LENGTH} isn't reached.
+     * Trims a message, ensuring that the maximum length {@link #MAX_MESSAGE_LENGTH} isn't reached.
      *
      * @param message message to format.
-     * @return formatted message (shortened if necessary).
+     * @return trimmed message (shortened if necessary).
      */
-    private String formatMessage(String message) {
+    private String trimMessage(String message) {
         if (message == null)
             return null;
         else if (message.length() > MAX_MESSAGE_LENGTH)
@@ -34,14 +34,14 @@ public class MessageInterfaceBinding implements InterfaceBinding<MessageInterfac
     @Override
     public void writeInterface(JsonGenerator generator, MessageInterface messageInterface) throws IOException {
         generator.writeStartObject();
-        generator.writeStringField(MESSAGE_PARAMETER, formatMessage(messageInterface.getMessage()));
+        generator.writeStringField(MESSAGE_PARAMETER, trimMessage(messageInterface.getMessage()));
         generator.writeArrayFieldStart(PARAMS_PARAMETER);
         for (String parameter : messageInterface.getParameters()) {
             generator.writeString(parameter);
         }
         generator.writeEndArray();
         if (messageInterface.getFormatted() != null) {
-            generator.writeStringField(FORMATTED_PARAMETER, formatMessage(messageInterface.getFormatted()));
+            generator.writeStringField(FORMATTED_PARAMETER, trimMessage(messageInterface.getFormatted()));
         }
         generator.writeEndObject();
     }


### PR DESCRIPTION
Done more correctly this time.

It's not setup for log4j yet. I've never understood how (or if) log4j supports parameterized log messages. I guess *maybe* `message` can be of type `ParameterizedMessage`? But I think we'd be failing today if that were true.

The most common pattern seems to be,

```
if logging at this level is enabled:
    log(manually_format(msg))
```

So maybe in log4j we just always send `message` as `formatted` (no params)? We can also leave out `formatted` on log4j.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-java/220)
<!-- Reviewable:end -->
