### PR TITLE
Changed default raven.async.queuesize from unlimited to 50.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Version 7.4.0
+-------------
+
+- Changed default ``raven.async.queuesize`` from unlimited to 50.
+
 Version 7.3.0
 -------------
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ The option to do so is `raven.async.gracefulshutdown`:
     http://public:private@host:port/1?raven.async.gracefulshutdown=false
 
 #### Queue size (advanced)
-The default queue used to store unprocessed events doesn't have a
-limit.
+The default queue used to store unprocessed events is limited to 50
+items. Additional items added once the queue is full are dropped and
+never sent to the Sentry server.
 Depending on the environment (if the memory is sparse) it is important to be
 able to control the size of that queue to avoid memory issues.
 
@@ -186,6 +187,10 @@ It is possible to set a maximum with the option `raven.async.queuesize`:
 
 This means that if the connection to the Sentry server is down, only the 100
 most recent events will be stored and processed as soon as the server is back up.
+
+The special value `-1` can be used to enable an unlimited queue. Beware
+that network connectivity or Sentry server issues could mean your process
+will run out of memory.
 
 #### Threads count (advanced)
 By default the thread pool used by the async connection contains one thread per

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -83,10 +83,11 @@ Queue and Thread Settings
 `````````````````````````
 
 Queue size (advanced):
-    The default queue used to store the not yet processed events doesn't
-    have a limit. Depending on the environment (if the memory is sparse)
-    it is important to be able to control the size of that queue to avoid
-    memory issues.
+    The default queue used to store unprocessed events is limited to 50
+    items. Additional items added once the queue is full are dropped and
+    never sent to the Sentry server. Depending on the environment (if the
+    memory is sparse) it is important to be able to control the size of
+    that queue to avoid memory issues.
 
     It is possible to set a maximum with the option ``raven.async.queuesize``::
 
@@ -95,6 +96,10 @@ Queue size (advanced):
     This means that if the connection to the Sentry server is down, only
     the 100 most recent events will be stored and processed as soon as the
     server is back up.
+
+    The special value ``-1`` can be used to enable an unlimited queue. Beware
+    that network connectivity or Sentry server issues could mean your process
+    will run out of memory.
 
 Threads count (advanced):
     By default the thread pool used by the async connection contains one

--- a/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
@@ -63,6 +63,11 @@ public class DefaultRavenFactory extends RavenFactory {
      * Option to hide common stackframes with enclosing exceptions.
      */
     public static final String HIDE_COMMON_FRAMES_OPTION = "raven.stacktrace.hidecommon";
+    /**
+     * The default async queue size if none is provided.
+     */
+    public static final int QUEUE_SIZE_DEFAULT = 50;
+
     private static final Logger logger = LoggerFactory.getLogger(DefaultRavenFactory.class);
     private static final String FALSE = Boolean.FALSE.toString();
 
@@ -141,9 +146,14 @@ public class DefaultRavenFactory extends RavenFactory {
 
         BlockingDeque<Runnable> queue;
         if (dsn.getOptions().containsKey(QUEUE_SIZE_OPTION)) {
-            queue = new LinkedBlockingDeque<>(Integer.parseInt(dsn.getOptions().get(QUEUE_SIZE_OPTION)));
+            int queueSize = Integer.parseInt(dsn.getOptions().get(QUEUE_SIZE_OPTION));
+            if (queueSize == -1) {
+                queue = new LinkedBlockingDeque<>();
+            } else {
+                queue = new LinkedBlockingDeque<>(queueSize);
+            }
         } else {
-            queue = new LinkedBlockingDeque<>();
+            queue = new LinkedBlockingDeque<>(QUEUE_SIZE_DEFAULT);
         }
 
         ExecutorService executorService = new ThreadPoolExecutor(


### PR DESCRIPTION
This is low hanging fruit fix for #212.

On an unrelated note, `docs/` and `README` are rather out of sync... I caught it this time but should probably reconcile them in general? Or is that on purpose. (I'm also sure I was the cause of some of it)