### PR TITLE
Add more debugging information to ``RavenFactory.ravenInstance``.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Version 7.4.1
+-------------
+
+- Add more debugging information to ``RavenFactory.ravenInstance``.
+
 Version 7.4.0
 -------------
 

--- a/raven/src/main/java/com/getsentry/raven/RavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenFactory.java
@@ -98,8 +98,8 @@ public abstract class RavenFactory {
             }
 
             logger.debug("Attempting to use '{}' as a Raven factory.", ravenFactory);
+            triedFactories.add(name);
             try {
-                triedFactories.add(name);
                 Raven ravenInstance = ravenFactory.createRavenInstance(dsn);
                 logger.debug("The raven factory '{}' created an instance of Raven.", ravenFactory);
                 return ravenInstance;

--- a/raven/src/main/java/com/getsentry/raven/RavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenFactory.java
@@ -4,6 +4,7 @@ import com.getsentry.raven.dsn.Dsn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -81,23 +82,70 @@ public abstract class RavenFactory {
      * @throws IllegalStateException when no instance of Raven has been created.
      */
     public static Raven ravenInstance(Dsn dsn, String ravenFactoryName) {
-        //Loop through registered factories
         logger.debug("Attempting to find a working Raven factory");
+
+        // Loop through registered factories, keeping track of which classes we skip, which we try to instantiate,
+        // and the last exception thrown.
+        ArrayList<String> skippedFactories = new ArrayList<>();
+        ArrayList<String> triedFactories = new ArrayList<>();
+        RuntimeException lastExc = null;
+
         for (RavenFactory ravenFactory : getRegisteredFactories()) {
-            if (ravenFactoryName != null && !ravenFactoryName.equals(ravenFactory.getClass().getName()))
+            String name = ravenFactory.getClass().getName();
+            if (ravenFactoryName != null && !ravenFactoryName.equals(name)) {
+                skippedFactories.add(name);
                 continue;
+            }
 
             logger.debug("Attempting to use '{}' as a Raven factory.", ravenFactory);
             try {
+                triedFactories.add(name);
                 Raven ravenInstance = ravenFactory.createRavenInstance(dsn);
                 logger.debug("The raven factory '{}' created an instance of Raven.", ravenFactory);
                 return ravenInstance;
             } catch (RuntimeException e) {
+                lastExc = e;
                 logger.debug("The raven factory '{}' couldn't create an instance of Raven.", ravenFactory, e);
             }
         }
 
-        throw new IllegalStateException("Couldn't create a raven instance for '" + dsn + "'");
+        // Throw an IllegalStateException that attempts to be helpful.
+        StringBuilder sb = new StringBuilder();
+        sb.append("Couldn't create a raven instance for: '");
+        sb.append(dsn);
+        sb.append('\'');
+        if (ravenFactoryName != null) {
+            sb.append("; ravenFactoryName: ");
+            sb.append(ravenFactoryName);
+
+            if (skippedFactories.isEmpty()) {
+                sb.append("; no skipped factories");
+            } else {
+                sb.append("; skipped factories: ");
+                String delim = "";
+                for (String skippedFactory : skippedFactories) {
+                    sb.append(delim);
+                    sb.append(skippedFactory);
+                    delim = ", ";
+                }
+            }
+        }
+
+        if (triedFactories.isEmpty()) {
+            sb.append("; no factories tried!");
+            throw new IllegalStateException(sb.toString());
+        }
+
+        sb.append("; tried factories: ");
+        String delim = "";
+        for (String triedFactory : triedFactories) {
+            sb.append(delim);
+            sb.append(triedFactory);
+            delim = ", ";
+        }
+
+        sb.append("; cause contains exception thrown by the last factory tried.");
+        throw new IllegalStateException(sb.toString(), lastExc);
     }
 
     /**


### PR DESCRIPTION
#183 

Used to provide this:

```
[WARNING] 
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:293)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: Couldn't create a raven instance for 'Dsn{uri=http://localhost:9999/}'
	at com.getsentry.raven.RavenFactory.ravenInstance(RavenFactory.java:100)
	at com.getsentry.example.Application.main(Application.java:16)
	... 6 more
```

Now provides output like this:

```
[WARNING] 
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:293)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: Couldn't create a raven instance for: 'Dsn{uri=http://localhost:9999/}'; ravenFactoryName: com.getsentry.example.TestFactory; skipped factories: com.getsentry.raven.DefaultRavenFactory; tried factories: com.getsentry.example.TestFactory; cause contains exception thrown by the last factory tried.
	at com.getsentry.raven.RavenFactory.ravenInstance(RavenFactory.java:148)
	at com.getsentry.example.Application.main(Application.java:16)
	... 6 more
Caused by: java.lang.ArithmeticException: / by zero
	at com.getsentry.example.TestFactory.createRavenInstance(TestFactory.java:10)
	at com.getsentry.raven.RavenFactory.ravenInstance(RavenFactory.java:103)
	... 7 more
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-java/229)
<!-- Reviewable:end -->
