### PR TITLE
Ensure contexts are removed from active contexts set after test completion.

### DIFF
--- a/raven/src/test/java/com/getsentry/raven/connection/EventSendFailureCallbackTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/EventSendFailureCallbackTest.java
@@ -2,8 +2,10 @@ package com.getsentry.raven.connection;
 
 import com.getsentry.raven.DefaultRavenFactory;
 import com.getsentry.raven.Raven;
+import com.getsentry.raven.RavenContext;
 import com.getsentry.raven.dsn.Dsn;
 import com.getsentry.raven.event.Event;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -12,6 +14,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EventSendFailureCallbackTest {
+
+    @AfterMethod
+    private void afterMethod() {
+        for (RavenContext ctx : RavenContext.getActiveContexts()) {
+            ctx.deactivate();
+        }
+    }
 
     @Test
     public void testSimpleCallback() {
@@ -38,8 +47,6 @@ public class EventSendFailureCallbackTest {
         raven.sendMessage("Message that will fail because DSN points to garbage.");
 
         assertThat(flag.get(), is(true));
-
-        raven.getContext().deactivate();
     }
 
     @Test
@@ -63,8 +70,6 @@ public class EventSendFailureCallbackTest {
         String dsn = "https://foo:bar@localhost:1234/1?raven.async=false";
         Raven raven = factory.createRavenInstance(new Dsn(dsn));
         raven.sendMessage("Message that will fail because DSN points to garbage.");
-
-        raven.getContext().deactivate();
     }
 
 }

--- a/raven/src/test/java/com/getsentry/raven/connection/EventSendFailureCallbackTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/EventSendFailureCallbackTest.java
@@ -38,6 +38,8 @@ public class EventSendFailureCallbackTest {
         raven.sendMessage("Message that will fail because DSN points to garbage.");
 
         assertThat(flag.get(), is(true));
+
+        raven.getContext().deactivate();
     }
 
     @Test
@@ -61,6 +63,8 @@ public class EventSendFailureCallbackTest {
         String dsn = "https://foo:bar@localhost:1234/1?raven.async=false";
         Raven raven = factory.createRavenInstance(new Dsn(dsn));
         raven.sendMessage("Message that will fail because DSN points to garbage.");
+
+        raven.getContext().deactivate();
     }
 
 }


### PR DESCRIPTION
If this `EventSendFailureCallbackTest` was executed before `RavenContextTest`, the `RavenContextTest` would fail due to [this precondition not being met](https://github.com/getsentry/raven-java/blob/8207d186f0ab03c72d0ea04fec983251b68214c2/raven/src/test/java/com/getsentry/raven/RavenContextTest.java#L22
), as the active contexts set was already populated with the two contexts created when these `Raven` instances were instantiated. (I'm not sure why this doesn't seem to be an issue on CI, though.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-java/238)
<!-- Reviewable:end -->
