### PR TITLE
Store last event sent in RavenContext.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Version 7.7.1
 - Add ``raven.maxmessagelength`` DSN option. (thanks vektory79)
 - Add ``Buffer`` interface, used to store events that fail to be sent to the Sentry server.
   Includes a DiskBuffer implementation and related ``raven.buffer.*`` options.
+- Add a way to retrieve the thread's last sent Event ID, if any. Useful for integrating
+  with the user feedback feature.
 
 Version 7.7.0
 -------------

--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -197,6 +197,12 @@ public class Raven {
     // Static helper methods follow
     // --------------------------------------------------------
 
+    /**
+     * Returns the last statically stored Raven instance or throws a {@link NullPointerException}
+     * if one hasn't been constructed and stored yet.
+     *
+     * @return statically stored {@link Raven} instance
+     */
     public static Raven getStoredInstance() {
         if (stored == null) {
             throw new NullPointerException("No stored Raven instance is available to use."

--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -95,6 +95,8 @@ public class Raven {
             connection.send(event);
         } catch (Exception e) {
             logger.error("An exception occurred while sending the event to Sentry.", e);
+        } finally {
+            context.get().setLastEventId(event.getId());
         }
     }
 
@@ -195,7 +197,7 @@ public class Raven {
     // Static helper methods follow
     // --------------------------------------------------------
 
-    private static Raven getStoredInstance() {
+    public static Raven getStoredInstance() {
         if (stored == null) {
             throw new NullPointerException("No stored Raven instance is available to use."
                 + " You must construct a Raven instance before using the static Raven methods.");

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * RavenContext is used to hold {@link ThreadLocal} context data (such as
@@ -41,6 +42,8 @@ public class RavenContext implements AutoCloseable {
      * The number of {@link Breadcrumb}s to keep in the ring buffer by default.
      */
     private static final int DEFAULT_BREADCRUMB_LIMIT = 100;
+
+    private UUID lastEventId;
 
     /**
      * Ring buffer of {@link Breadcrumb} objects.
@@ -82,6 +85,7 @@ public class RavenContext implements AutoCloseable {
      */
     public void clear() {
         breadcrumbs.clear();
+        lastEventId = null;
     }
 
     /**
@@ -122,4 +126,21 @@ public class RavenContext implements AutoCloseable {
         breadcrumbs.add(breadcrumb);
     }
 
+    /**
+     * Store the UUID of the last sent event by this thread, useful for handling user feedback.
+     *
+     * @param id UUID of the last event sent by this thread.
+     */
+    public void setLastEventId(UUID id) {
+        lastEventId = id;
+    }
+
+    /**
+     * Get the UUID of the last sent event by this thread, useful for handling user feedback.
+     *
+     * @return UUID of the last event sent by this thread.
+     */
+    public UUID getLastEventId() {
+        return lastEventId;
+    }
 }

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -136,7 +136,11 @@ public class RavenContext implements AutoCloseable {
     }
 
     /**
-     * Get the UUID of the last sent event by this thread, useful for handling user feedback.
+     * Get the UUID of the last event sent by this thread, useful for handling user feedback.
+     *
+     * <b>Returns null</b> if no event has been sent by this thread or if the event has been
+     * cleared. For example the RavenServletRequestListener clears the thread's RavenContext
+     * at the end of each request.
      *
      * @return UUID of the last event sent by this thread.
      */

--- a/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
+++ b/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
@@ -1,5 +1,7 @@
 package com.getsentry.raven.servlet;
 
+import com.getsentry.raven.Raven;
+
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestEvent;
 import javax.servlet.ServletRequestListener;
@@ -20,12 +22,15 @@ public class RavenServletRequestListener implements ServletRequestListener {
     @Override
     public void requestDestroyed(ServletRequestEvent servletRequestEvent) {
         THREAD_REQUEST.remove();
+
+        Raven.getStoredInstance().getContext().clear();
     }
 
     @Override
     public void requestInitialized(ServletRequestEvent servletRequestEvent) {
         ServletRequest servletRequest = servletRequestEvent.getServletRequest();
-        if (servletRequest instanceof HttpServletRequest)
+        if (servletRequest instanceof HttpServletRequest) {
             THREAD_REQUEST.set((HttpServletRequest) servletRequest);
+        }
     }
 }

--- a/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
+++ b/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
@@ -1,6 +1,8 @@
 package com.getsentry.raven.servlet;
 
 import com.getsentry.raven.Raven;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestEvent;
@@ -13,6 +15,8 @@ import javax.servlet.http.HttpServletRequest;
  * in the event sent to Sentry.
  */
 public class RavenServletRequestListener implements ServletRequestListener {
+    private static final Logger logger = LoggerFactory.getLogger(RavenServletRequestListener.class);
+
     private static final ThreadLocal<HttpServletRequest> THREAD_REQUEST = new ThreadLocal<>();
 
     public static HttpServletRequest getServletRequest() {
@@ -23,7 +27,11 @@ public class RavenServletRequestListener implements ServletRequestListener {
     public void requestDestroyed(ServletRequestEvent servletRequestEvent) {
         THREAD_REQUEST.remove();
 
-        Raven.getStoredInstance().getContext().clear();
+        try {
+            Raven.getStoredInstance().getContext().clear();
+        } catch (Exception e) {
+            logger.error("Error clearing RavenContext state.", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a quick stab at ideas on how to handle user feedback, where basically the developer needs access to the last event sent during that request cycle.

If they sent the event manually themselves, they have access to the Event (and thus ID) already. This is for the unhandled exception (logger) case.

It's pretty overly verbose right now, but would be available at: `Raven.getStoredInstance().getContext().getLastEventId()`

There are a few issues here:
* I've decided to only store the Event ID, not the Event, because those could be large in aggregate, or hold references to other data (?).
* Because most users interact via logging frameworks, they'll need static access to Raven to get the Event ID. Thankfully we recently started storing it statically and we have `getStoredInstance()` (which I had to make `public`).
* We likely want to clear threadlocal Breadcrumbs and lastEventId after each request, so I've added that to the servlet listener. This (or something like it) should probably go in regardless of this PR.
* The names/usage is verbose. Do we want to make these first class static methods that hang off `Raven`? `Raven.getLastEventId` etc? The static interface here is kind of exploding.
* Should `lastEventId` be a first class field, or should `Context` have a `Map<String, String>` to stash random shit on?
* Am I misunderstanding user feedback or doing something completely wrong?