### PR TITLE
Add raven-android submodule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,28 +49,7 @@ To use it with maven, add the following repository:
 ```
 
 ## Android
-Raven works on Android, and relies on the
-[ServiceLoader](https://developer.android.com/reference/java/util/ServiceLoader.html)
-system which uses the content of `META-INF/services`.
-This is used to declare the `RavenFactory` implementations (to allow more
-control over the automatically generated instances of `Raven`) in
-`META-INF/services/com.getsentry.raven.RavenFactory`.
-
-Unfortunately, when the APK is built, the content of `META-INF/services` in
-the dependencies is lost, this prevents Raven from working properly. Some
-solutions exist:
-
- - Use [maven-android-plugin](http://simpligility.github.io/android-maven-plugin/)
- which has already solved this
-[problem](https://web.archive.org/web/20150523160437/http://code.google.com/p/maven-android-plugin/issues/detail?id=97)
- - Manually create a `META-INF/services/com.getsentry.raven.RavenFactory` for
- the project which will contain the canonical name of the implementation of
- `RavenFactory` (ie. `com.getsentry.raven.DefaultRavenFactory`).
- - Manually register the `RavenFactory` when the application starts:
-
- ```java
- RavenFactory.registerFactory(new DefaultRavenFactory());
- ```
+Raven works on Android, please see the [Android README](https://github.com/getsentry/raven-java/blob/raven-android-start/raven-android/README.md).
 
 ## HTTP Request Context
 If the runtime environment utilizes Servlets, events that are created during

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
 
     <modules>
         <module>raven</module>
+        <module>raven-android</module>
         <module>raven-appengine</module>
         <module>raven-log4j</module>
         <module>raven-logback</module>

--- a/raven-android/README.md
+++ b/raven-android/README.md
@@ -1,0 +1,61 @@
+# Raven-Android
+
+## Installation
+
+### Gradle (Android Studio)
+
+In your `app/build.gradle` add: `compile 'com.getsentry.raven:raven-android:7.6.0'`
+
+### Other dependency managers
+Details in the [central Maven repository](https://search.maven.org/#artifactdetails%7Ccom.getsentry.raven%7Craven-android%7C7.6.0%7Cjar).
+
+## Usage
+
+### Configuration
+
+Configure your Sentry DSN (client key) in `AndroidManifest.xml`:
+
+```xml
+<application>
+  <meta-data
+    android:name="com.getsentry.raven.android.DSN"
+    android:value="https://publicKey:secretKey@host:port/1?options" />
+</application>
+```
+
+Your application must also have permission to access the internet in order to send
+event to the Sentry server. In `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+```
+
+Then, in your application's `onCreate`, initialize the Raven client:
+
+```java
+import com.getsentry.raven.android.Raven;
+
+// `this` is your main Activity
+Raven.init(this.getApplicationContext());
+```
+
+Now you can use `Raven` to capture events in your application:
+
+```java
+// Pass a String event 
+Raven.capture("Error message");
+
+// Or pass it a throwable
+try {
+  something()
+} catch (Exception e) {
+  Raven.capture(e);
+}
+
+// Or build an event yourself
+EventBuilder eventBuilder = new EventBuilder()
+                              .withMessage("Exception caught")
+                              .withLevel(Event.Level.ERROR);
+Raven.capture(eventBuilder.build());
+```

--- a/raven-android/pom.xml
+++ b/raven-android/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.getsentry.raven</groupId>
+        <artifactId>raven-all</artifactId>
+        <version>7.7.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>raven-android</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Raven-Java for Android</name>
+    <description>Android Raven-Java client.</description>
+
+    <properties>
+        <android.version>4.1.1.4</android.version>
+        <junit.version>4.12</junit.version>
+        <robolectric.version>2.4</robolectric.version>
+        <maven-ant.version>2.1.3</maven-ant.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>raven</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
+            <version>${android.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.robolectric</groupId>
+            <artifactId>robolectric</artifactId>
+            <version>${robolectric.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-ant-tasks</artifactId>
+            <version>${maven-ant.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Integration tests dependencies -->
+        <!-- Raven Test-jar does not provide test dependencies transitively -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>raven</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/raven-android/src/main/java/com/getsentry/raven/android/AndroidRavenFactory.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/AndroidRavenFactory.java
@@ -1,0 +1,61 @@
+package com.getsentry.raven.android;
+
+import android.content.Context;
+import android.util.Log;
+import com.getsentry.raven.*;
+import com.getsentry.raven.android.event.helper.AndroidEventBuilderHelper;
+import com.getsentry.raven.buffer.Buffer;
+import com.getsentry.raven.buffer.DiskBuffer;
+import com.getsentry.raven.dsn.Dsn;
+
+import java.io.File;
+
+/**
+ * RavenFactory that handles Android-specific construction, like taking advantage
+ * of the Android Context instance.
+ */
+public class AndroidRavenFactory extends DefaultRavenFactory {
+
+    /**
+     * Logger tag.
+     */
+    public static final String TAG = AndroidRavenFactory.class.getName();
+    /**
+     * Default Buffer directory name.
+     */
+    private static final String DEFAULT_BUFFER_DIR = "raven-buffered-events";
+
+    private Context ctx;
+
+    /**
+     * Construct an AndroidRavenFactory using the specified Android Context.
+     *
+     * @param ctx Android Context.
+     */
+    public AndroidRavenFactory(Context ctx) {
+        this.ctx = ctx;
+
+        Log.d(TAG, "Construction of Android Raven.");
+    }
+
+    @Override
+    public com.getsentry.raven.Raven createRavenInstance(Dsn dsn) {
+        com.getsentry.raven.Raven ravenInstance = super.createRavenInstance(dsn);
+        ravenInstance.addBuilderHelper(new AndroidEventBuilderHelper(ctx));
+        return ravenInstance;
+    }
+
+    @Override
+    protected Buffer getBuffer(Dsn dsn) {
+        File bufferDir;
+        if (dsn.getOptions().get(BUFFER_DIR_OPTION) != null) {
+            bufferDir = new File(dsn.getOptions().get(BUFFER_DIR_OPTION));
+        } else {
+            bufferDir = new File(ctx.getCacheDir().getAbsolutePath(), DEFAULT_BUFFER_DIR);
+        }
+
+        Log.d(TAG, "Using buffer dir: " + bufferDir.getAbsolutePath());
+        return new DiskBuffer(bufferDir, getBufferSize(dsn));
+    }
+
+}

--- a/raven-android/src/main/java/com/getsentry/raven/android/Raven.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/Raven.java
@@ -1,0 +1,178 @@
+package com.getsentry.raven.android;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.text.TextUtils;
+import android.util.Log;
+import com.getsentry.raven.DefaultRavenFactory;
+import com.getsentry.raven.RavenFactory;
+import com.getsentry.raven.dsn.Dsn;
+import com.getsentry.raven.event.Event;
+import com.getsentry.raven.event.EventBuilder;
+
+/**
+ * Android specific class to interface with Raven. Supplements the default Java classes
+ * with Android specific state and features.
+ */
+public final class Raven {
+
+    /**
+     * Logger tag.
+     */
+    public static final String TAG = Raven.class.getName();
+
+    private static volatile com.getsentry.raven.Raven raven;
+
+    /**
+     * Hide constructor.
+     */
+    private Raven() {
+
+    }
+
+    /**
+     * Initialize Raven using a DSN set in the AndroidManifest.
+     *
+     * @param ctx Android application ctx
+     */
+    public static void init(Context ctx) {
+        ctx = ctx.getApplicationContext();
+        String dsn = "";
+
+        // attempt to get DSN from AndroidManifest
+        ApplicationInfo appInfo = null;
+        try {
+            PackageManager packageManager = ctx.getPackageManager();
+            appInfo = packageManager.getApplicationInfo(ctx.getPackageName(), PackageManager.GET_META_DATA);
+            dsn = appInfo.metaData.getString("com.getsentry.raven.android.DSN");
+        } catch (PackageManager.NameNotFoundException e) {
+            // skip
+        }
+
+        if (TextUtils.isEmpty(dsn)) {
+            throw new NullPointerException("Raven DSN is not set, you must provide it via"
+                + "the constructor or AndroidManifest.");
+        }
+
+        init(ctx, new Dsn(dsn));
+    }
+
+    /**
+     * Initialize Raven using a string DSN.
+     *
+     * @param ctx Android application ctx
+     * @param dsn Sentry DSN string
+     */
+    public static void init(Context ctx, String dsn) {
+        init(ctx, new Dsn(dsn));
+    }
+
+    /**
+     * Initialize Raven using a DSN object. This is the 'main' initializer that other methods
+     * eventually call.
+     *
+     * @param ctx Android application ctx
+     * @param dsn Sentry DSN object
+     */
+    public static void init(Context ctx, Dsn dsn) {
+        if (raven != null) {
+            Log.e(TAG, "Initializing Raven multiple times.");
+            // cleanup existing connections
+            raven.closeConnection();
+        }
+
+        // Ensure we have the application context
+        Context context = ctx.getApplicationContext();
+
+        if (!Util.checkPermission(context, Manifest.permission.INTERNET)) {
+            Log.e(TAG, Manifest.permission.INTERNET + " is required to connect to the Sentry server,"
+                + " please add it to your AndroidManifest.xml");
+        }
+
+        Log.d(TAG, "Raven init with ctx='" + ctx.toString() + "' and dsn='" + dsn + "'");
+
+        String protocol = dsn.getProtocol();
+        if (!(protocol.equalsIgnoreCase("http") || protocol.equalsIgnoreCase("https"))) {
+            throw new IllegalArgumentException("Only 'http' or 'https' connections are supported in"
+                + " Raven Android, but received: " + protocol);
+        }
+
+        if ("false".equalsIgnoreCase(dsn.getOptions().get(DefaultRavenFactory.ASYNC_OPTION))) {
+            throw new IllegalArgumentException("Raven Android cannot use synchronous connections, remove '"
+                + DefaultRavenFactory.ASYNC_OPTION + "=false' from your DSN.");
+        }
+
+        RavenFactory.registerFactory(new AndroidRavenFactory(ctx));
+        raven = RavenFactory.ravenInstance(dsn);
+
+        setupUncaughtExceptionHandler();
+    }
+
+    /**
+     * Configures an Android uncaught exception handler which sends events to
+     * Sentry, then calls the preexisting uncaught exception handler.
+     */
+    private static void setupUncaughtExceptionHandler() {
+        Thread.UncaughtExceptionHandler currentHandler = Thread.getDefaultUncaughtExceptionHandler();
+        if (currentHandler != null) {
+            Log.d(TAG, "default UncaughtExceptionHandler class='" + currentHandler.getClass().getName() + "'");
+        }
+
+        // don't double register
+        if (!(currentHandler instanceof RavenUncaughtExceptionHandler)) {
+            // register as default exception handler
+            Thread.setDefaultUncaughtExceptionHandler(
+                new RavenUncaughtExceptionHandler(currentHandler));
+        }
+    }
+
+    /**
+     * Send an Event using the statically stored Raven instance.
+     *
+     * @param event Event to send to the Sentry server
+     */
+    public static void capture(Event event) {
+        raven.sendEvent(event);
+    }
+
+    /**
+     * Sends an exception (or throwable) to the Sentry server using the statically stored Raven instance.
+     * <p>
+     * The exception will be logged at the {@link Event.Level#ERROR} level.
+     *
+     * @param throwable exception to send to Sentry.
+     */
+    public static void capture(Throwable throwable) {
+        raven.sendException(throwable);
+    }
+
+    /**
+     * Sends a message to the Sentry server using the statically stored Raven instance.
+     * <p>
+     * The message will be logged at the {@link Event.Level#INFO} level.
+     *
+     * @param message message to send to Sentry.
+     */
+    public static void capture(String message) {
+        raven.sendMessage(message);
+    }
+
+    /**
+     * Builds and sends an {@link Event} to the Sentry server using the statically stored Raven instance.
+     *
+     * @param eventBuilder {@link EventBuilder} to send to Sentry.
+     */
+    public static void capture(EventBuilder eventBuilder) {
+        raven.sendEvent(eventBuilder);
+    }
+
+    /**
+     * Clear statically stored Raven instance. Useful for tests.
+     */
+    public static void clearStoredRaven() {
+        raven = null;
+    }
+
+}

--- a/raven-android/src/main/java/com/getsentry/raven/android/RavenUncaughtExceptionHandler.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/RavenUncaughtExceptionHandler.java
@@ -1,0 +1,54 @@
+package com.getsentry.raven.android;
+
+import android.util.Log;
+
+/**
+ * Sends any uncaught exception to Sentry, then passes the exception on to the pre-existing
+ * uncaught exception handler.
+ */
+class RavenUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+    /**
+     * Logger tag.
+     */
+    private static final String TAG = RavenUncaughtExceptionHandler.class.getName();
+
+    /**
+     * Reference to the pre-existing uncaught exception handler.
+     */
+    private Thread.UncaughtExceptionHandler defaultExceptionHandler;
+
+    /**
+     * Construct the {@link RavenUncaughtExceptionHandler}, storing the pre-existing uncaught exception
+     * handler.
+     *
+     * @param defaultExceptionHandler pre-existing uncaught exception handler
+     */
+    RavenUncaughtExceptionHandler(Thread.UncaughtExceptionHandler defaultExceptionHandler) {
+        this.defaultExceptionHandler = defaultExceptionHandler;
+    }
+
+    /**
+     * Sends any uncaught exception to Sentry, then passes the exception on to the pre-existing
+     * uncaught exception handler.
+     *
+     * @param thread thread that threw the error
+     * @param thrown the uncaught throwable
+     */
+    @Override
+    public void uncaughtException(Thread thread, Throwable thrown) {
+        Log.d(TAG, "Uncaught exception received.");
+
+        try {
+            com.getsentry.raven.Raven.capture(thrown);
+        } catch (Exception e) {
+            Log.e(TAG, "Error sending excepting to Sentry.", e);
+        }
+
+        if (defaultExceptionHandler != null) {
+            // call the original handler
+            defaultExceptionHandler.uncaughtException(thread, thrown);
+        }
+    }
+
+}

--- a/raven-android/src/main/java/com/getsentry/raven/android/Util.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/Util.java
@@ -1,0 +1,61 @@
+package com.getsentry.raven.android;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+/**
+ * Raven Android utility methods.
+ */
+public final class Util {
+
+    /**
+     * Hide constructor.
+     */
+    private Util() {
+
+    }
+
+    /**
+     * Check whether the application has been granted a certain permission.
+     *
+     * @param ctx Android application context
+     * @param permission Permission as a string
+     * @return true if permissions is granted
+     */
+    public static boolean checkPermission(Context ctx, String permission) {
+        int res = ctx.checkCallingOrSelfPermission(permission);
+        return (res == PackageManager.PERMISSION_GRANTED);
+    }
+
+    /**
+     * Check whether the application has internet access at a point in time.
+     *
+     * @param ctx Android application context
+     * @return true if the application has internet access
+     */
+    public static boolean isConnected(Context ctx) {
+        ConnectivityManager connectivityManager =
+            (ConnectivityManager) ctx.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+        return activeNetworkInfo != null && activeNetworkInfo.isConnected();
+    }
+
+    /**
+     * Check whether Raven should attempt to send an event, or just immediately store it.
+     *
+     * @param ctx Android application context
+     * @return true if Raven should attempt to send an event
+     */
+    public static boolean shouldAttemptToSend(Context ctx) {
+        if (!checkPermission(ctx, android.Manifest.permission.ACCESS_NETWORK_STATE)) {
+            // we can't check whether the connection is up, so the
+            // best we can do is try
+            return true;
+        }
+
+        return isConnected(ctx);
+    }
+
+}

--- a/raven-android/src/main/java/com/getsentry/raven/android/event/helper/AndroidEventBuilderHelper.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/event/helper/AndroidEventBuilderHelper.java
@@ -1,0 +1,40 @@
+package com.getsentry.raven.android.event.helper;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.util.Log;
+import com.getsentry.raven.event.EventBuilder;
+import com.getsentry.raven.event.helper.EventBuilderHelper;
+
+/**
+ * EventBuilderHelper that makes use of Android Context to populate some Event fields.
+ */
+public class AndroidEventBuilderHelper implements EventBuilderHelper {
+
+    /**
+     * Logger tag.
+     */
+    public static final String TAG = AndroidEventBuilderHelper.class.getName();
+
+    private Context ctx;
+
+    /**
+     * Construct given the provided Android {@link Context}.
+     *
+     * @param ctx Android application context.
+     */
+    public AndroidEventBuilderHelper(Context ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void helpBuildingEvent(EventBuilder eventBuilder) {
+        try {
+            int versionCode = ctx.getPackageManager().getPackageInfo(ctx.getPackageName(), 0).versionCode;
+            eventBuilder.withRelease(Integer.toString(versionCode));
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(TAG, "Couldn't find package version: " + e);
+        }
+    }
+
+}

--- a/raven-android/src/test/java/com/getsentry/raven/android/AndroidTest.java
+++ b/raven-android/src/test/java/com/getsentry/raven/android/AndroidTest.java
@@ -1,0 +1,24 @@
+package com.getsentry.raven.android;
+
+import com.getsentry.raven.BaseTest;
+import com.getsentry.raven.stub.SentryStub;
+import org.junit.After;
+import org.junit.Before;
+
+public class AndroidTest extends BaseTest {
+
+    protected SentryStub sentryStub;
+
+    @Before
+    public void setUp() throws Exception {
+        sentryStub = new SentryStub();
+        sentryStub.removeEvents();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Raven.clearStoredRaven();
+        sentryStub.removeEvents();
+    }
+
+}

--- a/raven-android/src/test/java/com/getsentry/raven/android/RavenIT.java
+++ b/raven-android/src/test/java/com/getsentry/raven/android/RavenIT.java
@@ -1,0 +1,31 @@
+package com.getsentry.raven.android;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.concurrent.Callable;
+
+@RunWith(RobolectricTestRunner.class)
+public class RavenIT extends AndroidTest {
+
+    @Test
+    public void test() throws Exception {
+        Assert.assertEquals(sentryStub.getEventCount(), 0);
+
+        RavenITActivity activity = Robolectric.setupActivity(RavenITActivity.class);
+        activity.sendEvent();
+
+        waitUntilTrue(1000, new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return sentryStub.getEventCount() == 1;
+            }
+        });
+
+        Assert.assertEquals(sentryStub.getEventCount(), 1);
+    }
+
+}

--- a/raven-android/src/test/java/com/getsentry/raven/android/RavenITActivity.java
+++ b/raven-android/src/test/java/com/getsentry/raven/android/RavenITActivity.java
@@ -1,0 +1,20 @@
+package com.getsentry.raven.android;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public class RavenITActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Raven.init(
+            this.getApplicationContext(),
+            "http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1");
+    }
+
+    public void sendEvent() {
+        Raven.capture("sendEvent()");
+    }
+
+}


### PR DESCRIPTION
I confused Github somehow. This is a clean diff moved from https://github.com/getsentry/raven-java/pull/231

---

Probably belongs in `raven-java`:
- [x] Add simple static interface for sending exceptions, setting breadcrumbs. (e.g. `Raven.sendException(e)` so they don't have to pass a client around everywhere)

Mandatory for Android "hello world" (this PR):
- [x] Figure out a naming scheme for classes, they're wordy and/or confusing right now.
- [x] Enforce async for all communication. (networking on Main thread is an exception in Android)  https://developer.android.com/reference/android/os/AsyncTask.html
- [x] Check internet connectivity permissions and complain in development mode.
- [x] Take DSN from manifest, or constructor, else throw exception.
- [x] Store exceptions when offline, send later.
- [x] Add ability to set release, or take automatically from app version if possible.

Follow-on issues to create:
- [ ] Attach app/phone data automatically. (use `contexts` in json probably? https://github.com/getsentry/sentry/pull/3521)
- [ ] Breadcrumb support (and automatically add some crumbs if possible/sensible).
- [ ] Proguard handling. (like sourcemaps in JS, we can bundle a way to get source lines)
- [ ] Add ability to disable uncaught exception handler. (?)
- [ ] Set environment automatically if possible #232.
