### PR TITLE
Enable Customizing Appenders via Subclassing

### DIFF
--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -98,7 +98,7 @@ public class SentryAppender extends AbstractAppender {
      * Might be empty in which case no mapped tags are set.
      * </p>
      */
-    private Set<String> extraTags = Collections.emptySet();
+    protected Set<String> extraTags = Collections.emptySet();
 
     /**
      * Creates an instance of SentryAppender.
@@ -123,7 +123,7 @@ public class SentryAppender extends AbstractAppender {
         this.raven = raven;
     }
 
-    private SentryAppender(String name, Filter filter) {
+    protected SentryAppender(String name, Filter filter) {
         super(name, filter, null, true);
     }
 

--- a/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
@@ -269,7 +269,14 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         return eventBuilder.build();
     }
 
-    private Deque<SentryException> extractExceptionQueue(ILoggingEvent iLoggingEvent) {
+    /**
+     * Creates a sequence of {@link SentryExceptions} given a particular {@link ILoggingEvent}.
+     *
+     * @param iLoggingEvent Information detailing a particular logging event
+     *
+     * @return A {@link Deque} of {@link SentryExceptions} detailing the exception chain
+     */
+    protected Deque<SentryException> extractExceptionQueue(ILoggingEvent iLoggingEvent) {
         IThrowableProxy throwableProxy = iLoggingEvent.getThrowableProxy();
         Deque<SentryException> exceptions = new ArrayDeque<>();
         Set<IThrowableProxy> circularityDetector = new HashSet<>();
@@ -292,7 +299,17 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         return exceptions;
     }
 
-    private SentryException createSentryExceptionFrom(IThrowableProxy throwableProxy, StackTraceInterface stackTrace) {
+    /**
+     * Given a {@link IThrowableProxy} and a {@link StackTraceInterface} return
+     * a {@link SentryException} to be reported to Sentry.
+     *
+     * @param throwableProxy Information detailing a Throwable
+     * @param stackTrace The stacktrace associated with the Throwable.
+     *
+     * @return A {@link SentryException} object ready to be sent to Sentry.
+     */
+    protected SentryException createSentryExceptionFrom(IThrowableProxy throwableProxy,
+                                                        StackTraceInterface stackTrace) {
         String exceptionMessage = throwableProxy.getMessage();
         String[] packageNameSimpleName = extractPackageSimpleClassName(throwableProxy.getClassName());
         String exceptionPackageName = packageNameSimpleName[0];
@@ -301,7 +318,15 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         return new SentryException(exceptionMessage, exceptionClassName, exceptionPackageName, stackTrace);
     }
 
-    private String[] extractPackageSimpleClassName(String canonicalClassName) {
+    /**
+     * Given a {@link String} representing a classname, return Strings
+     * representing the package name and the class name individually.
+     *
+     * @param canonicalClassName A dotted-notation string representing a class name (eg. "java.util.Date")
+     *
+     * @return An array of {@link Strings}. The first of which is the package name. The second is the class name.
+     */
+    protected String[] extractPackageSimpleClassName(String canonicalClassName) {
         String[] packageNameSimpleName = new String[2];
         try {
             Class<?> exceptionClass = Class.forName(canonicalClassName);
@@ -322,7 +347,15 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         return packageNameSimpleName;
     }
 
-    private StackTraceElement[] toStackTraceElements(IThrowableProxy throwableProxy) {
+    /**
+     * Given a {@link IThrowableProxy} return an array of {@link StackTraceElement}s
+     * associated with the underlying {@link Throwable}.
+     *
+     * @param throwableProxy Information detailing a Throwable.
+     *
+     * @return The {@link StackTraceElement}s associated w/the underlying {@link Throwable}
+     */
+    protected StackTraceElement[] toStackTraceElements(IThrowableProxy throwableProxy) {
         StackTraceElementProxy[] stackTraceElementProxies = throwableProxy.getStackTraceElementProxyArray();
         StackTraceElement[] stackTraceElements = new StackTraceElement[stackTraceElementProxies.length];
 


### PR DESCRIPTION
It can be useful to customize how log appenders create `SentryEvents`. For example, [Clojure's ExceptionInfo object](https://clojuredocs.org/clojure.core/ex-info) can contain useful information about events. Being able to capture that information in a `SentryEvent` can be very valuable. This could easily be accomplished by a subclass if it could override the implementation of [createSentryExceptionFrom](https://github.com/getsentry/raven-java/blob/master/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java#L295).

This PR changes `private` methods and fields to `protected` in both the [Logback SentryAppender](https://github.com/getsentry/raven-java/blob/master/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java#L295) and the [log4j2 SentryAppender](https://github.com/getsentry/raven-java/blob/master/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java).

This provides the necessary protection as well as enables more customization. 