### PR TITLE
Add Filters to drop all Raven logs before they go to the Sentry server.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 7.7.2
 -------------
 
 - Loosen permission on some Appender/Handler methods to allow for easier overriding. (thanks briprowe)
+- Add Filters to drop all Raven logs before they go to the Sentry server.
 
 Version 7.7.1
 -------------

--- a/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
@@ -14,6 +14,7 @@ import com.getsentry.raven.util.Util;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.ErrorCode;
+import org.apache.log4j.spi.Filter;
 import org.apache.log4j.spi.LocationInfo;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.ThrowableInformation;
@@ -94,6 +95,8 @@ public class SentryAppender extends AppenderSkeleton {
         setServerName(Lookup.lookup("serverName"));
         setTags(Lookup.lookup("tags"));
         setExtraTags(Lookup.lookup("extraTags"));
+
+        this.addFilter(new DropRavenFilter());
     }
 
     /**
@@ -310,5 +313,16 @@ public class SentryAppender extends AppenderSkeleton {
     @Override
     public boolean requiresLayout() {
         return false;
+    }
+
+    private class DropRavenFilter extends Filter {
+        @Override
+        public int decide(LoggingEvent event) {
+            String loggerName = event.getLoggerName();
+            if (loggerName != null && loggerName.startsWith("com.getsentry.raven")) {
+                return Filter.DENY;
+            }
+            return Filter.NEUTRAL;
+        }
     }
 }

--- a/raven-log4j/src/test/java/com/getsentry/raven/log4j/SentryAppenderIT.java
+++ b/raven-log4j/src/test/java/com/getsentry/raven/log4j/SentryAppenderIT.java
@@ -10,7 +10,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class SentryAppenderIT {
-    private static final Logger logger = Logger.getLogger(SentryAppenderIT.class);
+    /*
+     We filter out loggers that start with `com.getsentry.raven`, so we deliberately
+     use a custom logger name here.
+     */
+    private static final Logger logger = Logger.getLogger("SentryAppenderIT: log4j");
     private SentryStub sentryStub;
 
     @BeforeMethod

--- a/raven-log4j/src/test/java/com/getsentry/raven/log4j/SentryAppenderIT.java
+++ b/raven-log4j/src/test/java/com/getsentry/raven/log4j/SentryAppenderIT.java
@@ -15,6 +15,7 @@ public class SentryAppenderIT {
      use a custom logger name here.
      */
     private static final Logger logger = Logger.getLogger("SentryAppenderIT: log4j");
+    private static final Logger ravenLogger = Logger.getLogger(SentryAppenderIT.class);
     private SentryStub sentryStub;
 
     @BeforeMethod
@@ -40,5 +41,12 @@ public class SentryAppenderIT {
         logger.error("This is an exception",
                 new UnsupportedOperationException("Test", new UnsupportedOperationException()));
         assertThat(sentryStub.getEventCount(), is(1));
+    }
+
+    @Test
+    public void testNoRavenLogging() throws Exception {
+        assertThat(sentryStub.getEventCount(), is(0));
+        ravenLogger.error("This is a test");
+        assertThat(sentryStub.getEventCount(), is(0));
     }
 }

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -108,14 +108,6 @@ public class SentryAppender extends AbstractAppender {
      */
     public SentryAppender() {
         this(APPENDER_NAME, null);
-        setRavenFactory(Lookup.lookup("ravenFactory"));
-        setRelease(Lookup.lookup("release"));
-        setEnvironment(Lookup.lookup("environment"));
-        setServerName(Lookup.lookup("serverName"));
-        setTags(Lookup.lookup("tags"));
-        setExtraTags(Lookup.lookup("extraTags"));
-
-        this.addFilter(new DropRavenFilter());
     }
 
     /**
@@ -136,6 +128,13 @@ public class SentryAppender extends AbstractAppender {
      */
     protected SentryAppender(String name, Filter filter) {
         super(name, filter, null, true);
+        setRavenFactory(Lookup.lookup("ravenFactory"));
+        setRelease(Lookup.lookup("release"));
+        setEnvironment(Lookup.lookup("environment"));
+        setServerName(Lookup.lookup("serverName"));
+        setTags(Lookup.lookup("tags"));
+        setExtraTags(Lookup.lookup("extraTags"));
+        this.addFilter(new DropRavenFilter());
     }
 
     /**

--- a/raven-log4j2/src/test/java/com/getsentry/raven/log4j2/SentryAppenderIT.java
+++ b/raven-log4j2/src/test/java/com/getsentry/raven/log4j2/SentryAppenderIT.java
@@ -11,7 +11,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class SentryAppenderIT {
-    private static final Logger logger = LogManager.getLogger(SentryAppenderIT.class);
+    /*
+     We filter out loggers that start with `com.getsentry.raven`, so we deliberately
+     use a custom logger name here.
+     */
+    private static final Logger logger = LogManager.getLogger("SentryAppenderIT: log4j2");
     private SentryStub sentryStub;
 
     @BeforeMethod

--- a/raven-log4j2/src/test/java/com/getsentry/raven/log4j2/SentryAppenderIT.java
+++ b/raven-log4j2/src/test/java/com/getsentry/raven/log4j2/SentryAppenderIT.java
@@ -16,6 +16,7 @@ public class SentryAppenderIT {
      use a custom logger name here.
      */
     private static final Logger logger = LogManager.getLogger("SentryAppenderIT: log4j2");
+    private static final Logger ravenLogger = LogManager.getLogger(SentryAppenderIT.class);
     private SentryStub sentryStub;
 
     @BeforeMethod
@@ -41,5 +42,12 @@ public class SentryAppenderIT {
         logger.error("This is an exception",
                 new UnsupportedOperationException("Test", new UnsupportedOperationException()));
         assertThat(sentryStub.getEventCount(), is(1));
+    }
+
+    @Test
+    public void testNoRavenLogging() throws Exception {
+        assertThat(sentryStub.getEventCount(), is(0));
+        ravenLogger.error("This is a test");
+        assertThat(sentryStub.getEventCount(), is(0));
     }
 }

--- a/raven-logback/src/test/java/com/getsentry/raven/logback/SentryAppenderIT.java
+++ b/raven-logback/src/test/java/com/getsentry/raven/logback/SentryAppenderIT.java
@@ -16,6 +16,7 @@ public class SentryAppenderIT {
      use a custom logger name here.
      */
     private static final Logger logger = LoggerFactory.getLogger("SentryAppenderIT: logback");
+    private static final Logger ravenLogger = LoggerFactory.getLogger(SentryAppenderIT.class);
     private SentryStub sentryStub;
 
     @BeforeMethod
@@ -42,5 +43,12 @@ public class SentryAppenderIT {
         logger.error("This is an exception",
                 new UnsupportedOperationException("Test", new UnsupportedOperationException()));
         assertThat(sentryStub.getEventCount(), is(1));
+    }
+
+    @Test
+    public void testNoRavenLogging() throws Exception {
+        assertThat(sentryStub.getEventCount(), is(0));
+        ravenLogger.error("This is a test");
+        assertThat(sentryStub.getEventCount(), is(0));
     }
 }

--- a/raven-logback/src/test/java/com/getsentry/raven/logback/SentryAppenderIT.java
+++ b/raven-logback/src/test/java/com/getsentry/raven/logback/SentryAppenderIT.java
@@ -11,7 +11,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class SentryAppenderIT {
-    private static final Logger logger = LoggerFactory.getLogger(SentryAppenderIT.class);
+    /*
+     We filter out loggers that start with `com.getsentry.raven`, so we deliberately
+     use a custom logger name here.
+     */
+    private static final Logger logger = LoggerFactory.getLogger("SentryAppenderIT: logback");
     private SentryStub sentryStub;
 
     @BeforeMethod

--- a/raven/README.md
+++ b/raven/README.md
@@ -32,7 +32,7 @@ Relies on:
 Add the `SentryHandler` to the `logging.properties` file:
 
 ```properties
-.level=WARN
+.level=WARNING
 handlers=com.getsentry.raven.jul.SentryHandler
 ```
 
@@ -82,7 +82,7 @@ itself. This is less flexible because it's harder to change when you run
 your application in different environments.
 
 ```properties
-.level=WARN
+.level=WARNING
 handlers=com.getsentry.raven.jul.SentryHandler
 com.getsentry.raven.jul.SentryHandler.dsn=https://host:port/1?options
 # Optional, provide tags

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.ErrorManager;
+import java.util.logging.Filter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -101,6 +102,7 @@ public class SentryHandler extends Handler {
         setExtraTags(Lookup.lookup("extraTags"));
 
         retrieveProperties();
+        this.setFilter(new DropRavenFilter());
     }
 
     /**
@@ -370,4 +372,11 @@ public class SentryHandler extends Handler {
         this.extraTags = Util.parseExtraTags(extraTags);
     }
 
+    private class DropRavenFilter implements Filter {
+        @Override
+        public boolean isLoggable(LogRecord record) {
+            String loggerName = record.getLoggerName();
+            return loggerName == null || !loggerName.startsWith("com.getsentry.raven");
+        }
+    }
 }

--- a/raven/src/test/java/com/getsentry/raven/jul/SentryHandlerIT.java
+++ b/raven/src/test/java/com/getsentry/raven/jul/SentryHandlerIT.java
@@ -12,7 +12,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class SentryHandlerIT {
-    private static final Logger logger = Logger.getLogger(SentryHandlerIT.class.getName());
+    /*
+     We filter out loggers that start with `com.getsentry.raven`, so we deliberately
+     use a custom logger name here.
+     */
+    private static final Logger logger = Logger.getLogger("SentryHandlerIT: jul");
     private SentryStub sentryStub;
 
     @BeforeMethod

--- a/raven/src/test/java/com/getsentry/raven/jul/SentryHandlerIT.java
+++ b/raven/src/test/java/com/getsentry/raven/jul/SentryHandlerIT.java
@@ -17,6 +17,7 @@ public class SentryHandlerIT {
      use a custom logger name here.
      */
     private static final Logger logger = Logger.getLogger("SentryHandlerIT: jul");
+    private static final Logger ravenLogger = Logger.getLogger(SentryHandlerIT.class.getName());
     private SentryStub sentryStub;
 
     @BeforeMethod
@@ -42,5 +43,12 @@ public class SentryHandlerIT {
         logger.log(Level.SEVERE, "This is an exception",
                 new UnsupportedOperationException("Test", new UnsupportedOperationException()));
         assertThat(sentryStub.getEventCount(), is(1));
+    }
+
+    @Test
+    public void testNoRavenLogging() throws Exception {
+        assertThat(sentryStub.getEventCount(), is(0));
+        ravenLogger.log(Level.SEVERE, "This is a test");
+        assertThat(sentryStub.getEventCount(), is(0));
     }
 }


### PR DESCRIPTION
@tkaemming this was on a whim, maybe there's some reason we didn't do this already? It seems like an obvious win to me. Should fix all deadlock issues, and for that matter I wonder if it'd allow us to drop the `RavenEnvironment` shit...