### PR TITLE
Drop existing contexts before running context test.

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -96,7 +96,7 @@ public class Raven {
         } catch (Exception e) {
             logger.error("An exception occurred while sending the event to Sentry.", e);
         } finally {
-            context.get().setLastEventId(event.getId());
+            getContext().setLastEventId(event.getId());
         }
     }
 

--- a/raven/src/test/java/com/getsentry/raven/RavenContextTest.java
+++ b/raven/src/test/java/com/getsentry/raven/RavenContextTest.java
@@ -13,10 +13,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 
+@Test(singleThreaded = true)
 public class RavenContextTest {
 
     @Test
     public void testActivateDeactivate() {
+        for (RavenContext context : RavenContext.getActiveContexts()) {
+            context.deactivate();
+        }
+
         RavenContext context = new RavenContext();
 
         assertThat(RavenContext.getActiveContexts(), emptyCollectionOf(RavenContext.class));


### PR DESCRIPTION
Noticed this on Travis, fails when they run in a different order. Also forced single threaded since it's checking shared mutable state.