### PR TITLE
Fix synchronization issue on SentryAppender Raven initialization

### DIFF
--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -234,8 +234,10 @@ public class SentryAppender extends AbstractAppender {
 
         RavenEnvironment.startManagingThread();
         try {
-            if (raven == null)
-                initRaven();
+            synchronized (this) {
+                if (raven == null)
+                    initRaven();
+            }
 
             Event event = buildEvent(logEvent);
             raven.sendEvent(event);


### PR DESCRIPTION
We ran into synchronization issues reproducible in this test:

```java
import org.apache.logging.log4j.LogManager;
import org.apache.logging.log4j.Logger;

public class Test {
	public static void main(String[] args) {
//		for(int i = 0; i < 10; ++i) {
			f();
//		}
	}

	static void f() {
		final Logger logger = LogManager.getFormatterLogger();

		Runnable r = () -> logger.warn("warning");

		Thread t1 = new Thread(r);
		Thread t2 = new Thread(r);
		t1.start();
		t2.start();
	}
}
```

`log4j2.xml`:
```<?xml version="1.0" encoding="utf-8"?>
<configuration shutdownHook="disable" packages="org.apache.logging.log4j.core,com.getsentry.raven.log4j2">
	<appenders>
		<console name="stdout-1">
			<patternlayout pattern="[%d{yyyy-MM-dd'T'HH:mm:ss.SSS}][%thread][%highlight{%-5level}{STYLE=Logback, DEBUG=magenta, TRACE=blue}][%logger{-1}] %msg%n"/>
		</console>

		<raven name="sentry">
			<filters>
				<ThresholdFilter level="WARN" onMatch="ACCEPT" />
				<ThresholdFilter level="ERROR" onMatch="ACCEPT" />
			</filters>
		</raven>
	</appenders>

	<loggers>
		<logger name="[snip]" level="DEBUG" additivity="false">
			<appenderref ref="stdout-1" />
			<appenderref ref="sentry" />
		</logger>
	</loggers>
</configuration>
```

output without this pull request applied:

```
[2017-01-03T15:37:40.518][Thread-1][WARN ][Test] warning
[2017-01-03T15:37:40.518][Thread-2][WARN ][Test] warning
[2017-01-03T15:37:40.524][Thread-1][WARN ][getsentry.raven.dsn.Dsn] Couldn't find a suitable DSN, defaulting to a Noop one.
[2017-01-03T15:37:40.527][Thread-2][WARN ][getsentry.raven.dsn.Dsn] Couldn't find a suitable DSN, defaulting to a Noop one.
2017-01-03 15:37:40,528 Thread-2 ERROR An exception occurred during the creation of a Raven instance java.util.NoSuchElementException
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:365)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
	at com.getsentry.raven.RavenFactory.getRegisteredFactories(RavenFactory.java:41)
	at com.getsentry.raven.RavenFactory.ravenInstance(RavenFactory.java:93)
	at com.getsentry.raven.log4j2.SentryAppender.initRaven(SentryAppender.java:259)
	at com.getsentry.raven.log4j2.SentryAppender.append(SentryAppender.java:239)
	at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:155)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:128)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:119)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:84)
	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:390)
	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:375)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:359)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:349)
	at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:63)
	at org.apache.logging.log4j.core.Logger.logMessage(Logger.java:146)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:1988)
	at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1960)
	at org.apache.logging.log4j.spi.AbstractLogger.warn(AbstractLogger.java:2516)
	at [snip]Test.lambda$f$0(Test.java:16)
	at java.lang.Thread.run(Thread.java:745)
```

output with pull request applied (like expected):

```
[snip]
[2017-01-03T15:31:49.944][Thread-2][WARN ][Test] warning
[2017-01-03T15:31:49.943][Thread-10][WARN ][Test] warning
[2017-01-03T15:31:49.949][Thread-1][WARN ][getsentry.raven.dsn.Dsn] Couldn't find a suitable DSN, defaulting to a Noop one.
```
