### PR TITLE
Restore thread interrupt status upon InterruptedException

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
@@ -112,6 +112,7 @@ public abstract class AbstractConnection implements Connection {
                 if (lockdown.get())
                     condition.await();
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 logger.warn("An exception occurred during the lockdown.", e);
             } finally {
                 lock.unlock();

--- a/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
@@ -137,6 +137,7 @@ public class AsyncConnection implements Connection {
             }
             logger.info("Shutdown finished.");
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             logger.error("Graceful shutdown interrupted, forcing the shutdown.");
             List<Runnable> tasks = executorService.shutdownNow();
             logger.info("{} tasks failed to execute before the shutdown.", tasks.size());

--- a/raven/src/main/java/com/getsentry/raven/connection/BufferedConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/BufferedConnection.java
@@ -129,6 +129,7 @@ public class BufferedConnection implements Connection {
             }
             logger.info("Shutdown finished.");
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             logger.error("Graceful shutdown interrupted, forcing the shutdown.");
             List<Runnable> tasks = executorService.shutdownNow();
             logger.info("{} tasks failed to execute before the shutdown.", tasks.size());


### PR DESCRIPTION
This allows calling threads to determine thread interruption occurred and respond accordingly.

https://www.ibm.com/developerworks/library/j-jtp05236/
http://www.javaspecialists.eu/archive/Issue056.html