### PR TITLE
Bump Maven plugins and deps, wait for Jetty test server to stop betwe…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
         <developer>
             <id>bretthoerner</id>
             <name>Brett Hoerner</name>
-            <email>brett@sentry.com</email>
+            <email>brett@sentry.io</email>
             <organization>Sentry</organization>
-            <organizationUrl>https://getsentry.com/</organizationUrl>
+            <organizationUrl>https://sentry.io/</organizationUrl>
         </developer>
     </developers>
     <contributors>
@@ -117,9 +117,9 @@
         <maven.compiler.target>7</maven.compiler.target>
 
         <!-- dependencies versions -->
-        <slf4j.version>1.7.21</slf4j.version>
+        <slf4j.version>1.7.22</slf4j.version>
         <findbugs.version>3.0.1</findbugs.version>
-        <jackson.version>2.7.3</jackson.version>
+        <jackson.version>2.7.6</jackson.version>
         <jmockit.version>1.14</jmockit.version>
         <testng.version>6.9.10</testng.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -192,7 +192,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>2.5.3</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <localCheckout>true</localCheckout>
@@ -209,7 +209,7 @@
             <plugin>
                 <groupId>com.github.github</groupId>
                 <artifactId>site-maven-plugin</artifactId>
-                <version>0.10</version>
+                <version>0.12</version>
                 <configuration>
                     <message>Creating site for ${project.artifactId} ${project.version}</message>
                     <path>${project.distributionManagement.site.url}</path>
@@ -228,7 +228,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.4</version>
+                <version>3.6</version>
                 <configuration>
                     <skipDeploy>true</skipDeploy>
                 </configuration>
@@ -236,7 +236,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.13</version>
+                <version>1.15</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -260,10 +260,11 @@
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>9.3.0.M1</version>
+                    <version>9.4.1.v20170120</version>
                     <configuration>
                         <scanIntervalSeconds>10</scanIntervalSeconds>
                         <stopKey>foo</stopKey>
+                        <stopWait>10</stopWait>
                         <stopPort>9999</stopPort>
                         <war>${project.build.directory}/webapps/sentry-stub.war</war>
                     </configuration>
@@ -292,12 +293,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
+                    <version>2.19.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.18.1</version>
+                    <version>2.19.1</version>
                     <executions>
                         <execution>
                             <id>integration-tests</id>
@@ -311,7 +312,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.0.0</version>
                     <executions>
                         <execution>
                             <id>analyze</id>
@@ -377,11 +378,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -393,19 +394,19 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>3.6</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -416,12 +417,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.9</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>2.10.4</version>
                 <configuration>
                     <excludePackageNames>com.getsentry.raven.util.base64*:com.getsentry.raven.sentrystub.util.base64</excludePackageNames>
                 </configuration>
@@ -429,7 +430,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -456,7 +457,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.4</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -469,7 +470,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.1</version>
+                        <version>2.10.4</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -482,7 +483,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -496,7 +497,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.5</version>
+                        <version>1.6.7</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>sonatype-nexus-staging</serverId>
@@ -527,7 +528,7 @@
                     <plugin>
                         <groupId>org.pitest</groupId>
                         <artifactId>pitest-maven</artifactId>
-                        <version>1.1.3</version>
+                        <version>1.1.11</version>
                         <configuration>
                             <targetTests>
                                 <param>*Test</param>

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>9.4.1.v20170120</version>
+                    <version>9.2.21.v20170120</version>
                     <configuration>
                         <scanIntervalSeconds>10</scanIntervalSeconds>
                         <stopKey>foo</stopKey>

--- a/raven-appengine/pom.xml
+++ b/raven-appengine/pom.xml
@@ -14,8 +14,7 @@
     <description>Raven module allowing to use GoogleApp Engine and its task queueing system.</description>
 
     <properties>
-        <appengine-api.version>1.9.34</appengine-api.version>
-        <logback.version>1.1.7</logback.version>
+        <appengine-api.version>1.9.49</appengine-api.version>
     </properties>
 
     <dependencies>
@@ -33,12 +32,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>

--- a/raven-log4j2/pom.xml
+++ b/raven-log4j2/pom.xml
@@ -15,7 +15,7 @@
     <description>log4j2 appender allowing to send logs to the Raven-Java client.</description>
 
     <properties>
-        <log4j2.version>2.5</log4j2.version>
+        <log4j2.version>2.8</log4j2.version>
     </properties>
 
     <dependencies>

--- a/raven-logback/pom.xml
+++ b/raven-logback/pom.xml
@@ -15,7 +15,7 @@
     <description>Logback appender allowing to send logs to the Raven-Java client.</description>
 
     <properties>
-        <logback.version>1.1.7</logback.version>
+        <logback.version>1.1.9</logback.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
…en tests.

This fixes an annoying issue I get like 80% of the time locally. I guess I figured I should bump all the other plugins just because.

```
[ERROR] Failed to execute goal org.eclipse.jetty:jetty-maven-plugin:9.4.1.v20170120:deploy-war (start-sentry-stub) on project raven-log4j: Failure: ShutdownMonitor already started -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.eclipse.jetty:jetty-maven-plugin:9.4.1.v20170120:deploy-war (start-sentry-stub) on project raven-log4j: Failure
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Failure
	at org.eclipse.jetty.maven.plugin.AbstractJettyMojo.startJetty(AbstractJettyMojo.java:488)
	at org.eclipse.jetty.maven.plugin.AbstractJettyMojo.execute(AbstractJettyMojo.java:328)
	at org.eclipse.jetty.maven.plugin.JettyRunWarMojo.execute(JettyRunWarMojo.java:64)
	at org.eclipse.jetty.maven.plugin.JettyDeployWar.execute(JettyDeployWar.java:65)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	... 20 more
Caused by: java.lang.IllegalStateException: ShutdownMonitor already started
	at org.eclipse.jetty.server.ShutdownMonitor.setPort(ShutdownMonitor.java:206)
	at org.eclipse.jetty.maven.plugin.AbstractJettyMojo.configureMonitor(AbstractJettyMojo.java:505)
	at org.eclipse.jetty.maven.plugin.AbstractJettyMojo.startJetty(AbstractJettyMojo.java:421)
	... 25 more
```