### PR TITLE
Better error messages when custom RavenFactory isn't found or is miss…

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,12 +344,28 @@ public class MyRavenFactory extends DefaultRavenFactory {
 }
 ```
 
-TODO: Manual example `RavenFactory.registerFactory(new TestFactory());`
+### Registration
+Next, you'll need to make your class known to Raven in one of two ways.
 
+#### Java ServiceLoader provider (recommended)
 You'll need to add a `ServiceLoader` provider file to your project at
 `src/main/resources/META-INF/services/com.getsentry.raven.RavenFactory` that contains
 the name of your class so that it will be considered as a candidate `RavenFactory`. For an example, see
 [how we configure the DefaultRavenFactory itself](https://github.com/getsentry/raven-java/blob/master/raven/src/main/resources/META-INF/services/com.getsentry.raven.RavenFactory).
 
+#### Manual registration
+You can also manually register your `RavenFactory` instance. Note that this should be done
+early in your application lifecycle so that your factory is available the first time
+you attempt to send an event to the Sentry server.
+```java
+class MyApp {
+    public static void main(String[] args) {
+        RavenFactory.registerFactory(new MyRavenFactory());
+        // ... your app code ...
+    }
+}
+```
+
+### Configuration
 Finally, see the `README` for the logger integration you use to find out how to
 configure it to use your custom `RavenFactory`.

--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ public class MyRavenFactory extends DefaultRavenFactory {
 }
 ```
 
+TODO: Manual example `RavenFactory.registerFactory(new TestFactory());`
+
 You'll need to add a `ServiceLoader` provider file to your project at
 `src/main/resources/META-INF/services/com.getsentry.raven.RavenFactory` that contains
 the name of your class so that it will be considered as a candidate `RavenFactory`. For an example, see

--- a/raven/src/main/java/com/getsentry/raven/RavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenFactory.java
@@ -109,7 +109,7 @@ public abstract class RavenFactory {
             }
         }
 
-        if (ravenFactoryName != null && triedFactories.size() < 1) {
+        if (ravenFactoryName != null && triedFactories.isEmpty()) {
             try {
                 // see if the provided class exists on the classpath at all
                 Class.forName(ravenFactoryName);

--- a/raven/src/main/java/com/getsentry/raven/RavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenFactory.java
@@ -109,6 +109,19 @@ public abstract class RavenFactory {
             }
         }
 
+        if (ravenFactoryName != null && triedFactories.size() < 1) {
+            try {
+                // see if the provided class exists on the classpath at all
+                Class.forName(ravenFactoryName);
+                logger.error(
+                    "The raven factory class '{}' is missing a ServiceLoader provider "
+                    + "for com.getsentry.raven.RavenFactory. "
+                    + "See: https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html", ravenFactoryName);
+            } catch (ClassNotFoundException e) {
+                logger.error("The raven factory class name '{}' was specified but the class was not found on your classpath.", ravenFactoryName);
+            }
+        }
+
         // Throw an IllegalStateException that attempts to be helpful.
         StringBuilder sb = new StringBuilder();
         sb.append("Couldn't create a raven instance for: '");

--- a/raven/src/main/java/com/getsentry/raven/RavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenFactory.java
@@ -77,12 +77,12 @@ public abstract class RavenFactory {
      * Creates an instance of Raven using the provided DSN and the specified factory.
      *
      * @param dsn              Data Source Name of the Sentry server.
-     * @param ravenFactoryName name of the raven factory to use to generate an instance of Raven.
+     * @param ravenFactoryName name of the RavenFactory to use to generate an instance of Raven.
      * @return an instance of Raven.
      * @throws IllegalStateException when no instance of Raven has been created.
      */
     public static Raven ravenInstance(Dsn dsn, String ravenFactoryName) {
-        logger.debug("Attempting to find a working Raven factory");
+        logger.debug("Attempting to find a working RavenFactory");
 
         // Loop through registered factories, keeping track of which classes we skip, which we try to instantiate,
         // and the last exception thrown.
@@ -97,15 +97,15 @@ public abstract class RavenFactory {
                 continue;
             }
 
-            logger.debug("Attempting to use '{}' as a Raven factory.", ravenFactory);
+            logger.debug("Attempting to use '{}' as a RavenFactory.", ravenFactory);
             triedFactories.add(name);
             try {
                 Raven ravenInstance = ravenFactory.createRavenInstance(dsn);
-                logger.debug("The raven factory '{}' created an instance of Raven.", ravenFactory);
+                logger.debug("The RavenFactory '{}' created an instance of Raven.", ravenFactory);
                 return ravenInstance;
             } catch (RuntimeException e) {
                 lastExc = e;
-                logger.debug("The raven factory '{}' couldn't create an instance of Raven.", ravenFactory, e);
+                logger.debug("The RavenFactory '{}' couldn't create an instance of Raven.", ravenFactory, e);
             }
         }
 
@@ -114,11 +114,11 @@ public abstract class RavenFactory {
                 // see if the provided class exists on the classpath at all
                 Class.forName(ravenFactoryName);
                 logger.error(
-                    "The raven factory class '{}' is missing a ServiceLoader provider "
-                    + "for com.getsentry.raven.RavenFactory. "
-                    + "See: https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html", ravenFactoryName);
+                    "The RavenFactory class '{}' was found on your classpath but was not "
+                    + "registered with Raven, see: "
+                    + "https://github.com/getsentry/raven-java/#custom-ravenfactory", ravenFactoryName);
             } catch (ClassNotFoundException e) {
-                logger.error("The raven factory class name '{}' was specified but "
+                logger.error("The RavenFactory class name '{}' was specified but "
                     + "the class was not found on your classpath.", ravenFactoryName);
             }
         }

--- a/raven/src/main/java/com/getsentry/raven/RavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenFactory.java
@@ -118,7 +118,8 @@ public abstract class RavenFactory {
                     + "for com.getsentry.raven.RavenFactory. "
                     + "See: https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html", ravenFactoryName);
             } catch (ClassNotFoundException e) {
-                logger.error("The raven factory class name '{}' was specified but the class was not found on your classpath.", ravenFactoryName);
+                logger.error("The raven factory class name '{}' was specified but "
+                    + "the class was not found on your classpath.", ravenFactoryName);
             }
         }
 


### PR DESCRIPTION
…ing a provider.

#286 

Example new messages;

Class exists but they didn't set it up right:
```
13:43:40.381 [com.getsentry.example.Application.main()] ERROR com.getsentry.raven.RavenFactory - The raven factory class 'com.getsentry.example.TestFactory' is missing a ServiceLoader provider for com.getsentry.raven.RavenFactory. See: https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html
```

Class doesn't exist:
```
13:44:05.550 [com.getsentry.example.Application.main()] ERROR com.getsentry.raven.RavenFactory - The raven factory class name 'barf' was specified but the class was not found on your classpath.
```