### PR TITLE
RavenContext changes

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -36,6 +36,18 @@ public class Raven {
      */
     private volatile Connection connection;
 
+    /**
+     * Thread local set of active {@link Raven} objects. Note that an {@link IdentityHashMap}
+     * is used instead of a Set because there is no identity-set in the Java
+     * standard library.
+     * <p>
+     * A set of active {@link Raven} instances is required in order to support running multiple Raven
+     * clients within a single process.
+     * <p>
+     * This must be static and {@link ThreadLocal} so that users can retrieve any active
+     * instances globally, without passing instances all the way down their
+     * stacks. See {@link com.getsentry.raven.event.Breadcrumbs} for an example of how this may be used.
+     */
     private static Map<Raven, Raven> instances = Collections.synchronizedMap(new IdentityHashMap<Raven, Raven>());
 
     /**
@@ -43,7 +55,7 @@ public class Raven {
      * isn't a concurrent set in the standard library.
      */
     private final Set<EventBuilderHelper> builderHelpers =
-            Collections.newSetFromMap(new ConcurrentHashMap<EventBuilderHelper, Boolean>());
+        Collections.newSetFromMap(new ConcurrentHashMap<EventBuilderHelper, Boolean>());
     private final ThreadLocal<RavenContext> context = new ThreadLocal<RavenContext>() {
         @Override
         protected RavenContext initialValue() {
@@ -53,7 +65,7 @@ public class Raven {
 
     /**
      * Constructs a Raven instance.
-     * <p>
+     *
      * Note that the most recently constructed instance is stored statically so it can be used with
      * the static helper methods.
      *
@@ -68,7 +80,7 @@ public class Raven {
 
     /**
      * Constructs a Raven instance using the provided connection.
-     * <p>
+     *
      * Note that the most recently constructed instance is stored statically so it can be used with
      * the static helper methods.
      *
@@ -120,14 +132,14 @@ public class Raven {
 
     /**
      * Sends a message to the Sentry server.
-     * <p>
+     *
      * The message will be logged at the {@link Event.Level#INFO} level.
      *
      * @param message message to send to Sentry.
      */
     public void sendMessage(String message) {
         EventBuilder eventBuilder = new EventBuilder().withMessage(message)
-                .withLevel(Event.Level.INFO);
+            .withLevel(Event.Level.INFO);
         runBuilderHelpers(eventBuilder);
         Event event = eventBuilder.build();
         sendEvent(event);
@@ -135,15 +147,15 @@ public class Raven {
 
     /**
      * Sends an exception (or throwable) to the Sentry server.
-     * <p>
+     *
      * The exception will be logged at the {@link Event.Level#ERROR} level.
      *
      * @param throwable exception to send to Sentry.
      */
     public void sendException(Throwable throwable) {
         EventBuilder eventBuilder = new EventBuilder().withMessage(throwable.getMessage())
-                .withLevel(Event.Level.ERROR)
-                .withSentryInterface(new ExceptionInterface(throwable));
+            .withLevel(Event.Level.ERROR)
+            .withSentryInterface(new ExceptionInterface(throwable));
         runBuilderHelpers(eventBuilder);
         Event event = eventBuilder.build();
         sendEvent(event);
@@ -218,7 +230,7 @@ public class Raven {
     private static void verifyStoredInstance() {
         if (stored == null) {
             throw new NullPointerException("No stored Raven instance is available to use."
-                    + " You must construct a Raven instance before using the static Raven methods.");
+                + " You must construct a Raven instance before using the static Raven methods.");
         }
     }
 
@@ -234,7 +246,7 @@ public class Raven {
 
     /**
      * Sends an exception (or throwable) to the Sentry server using the statically stored Raven instance.
-     * <p>
+     *
      * The exception will be logged at the {@link Event.Level#ERROR} level.
      *
      * @param throwable exception to send to Sentry.
@@ -246,7 +258,7 @@ public class Raven {
 
     /**
      * Sends a message to the Sentry server using the statically stored Raven instance.
-     * <p>
+     *
      * The message will be logged at the {@link Event.Level#INFO} level.
      *
      * @param message message to send to Sentry.
@@ -268,7 +280,7 @@ public class Raven {
 
     /**
      * Returns any currently active {@link Raven} instances (Active instances are instances on which close has not been called).
-     * @return List of Raven instances
+     * @return List of active Raven instances
      */
     public static List<Raven> getInstances() {
         return new ArrayList<>(instances.keySet());
@@ -276,7 +288,7 @@ public class Raven {
 
     /**
      * Returns any active {@link RavenContext}s.
-     * @return List or RavenContext instances
+     * @return List of active RavenContext instances
      */
     public static List<RavenContext> getContexts() {
         List<RavenContext> contexts = new ArrayList<>();

--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -132,7 +132,7 @@ public class Raven {
 
     /**
      * Sends a message to the Sentry server.
-     *
+     * <p>
      * The message will be logged at the {@link Event.Level#INFO} level.
      *
      * @param message message to send to Sentry.
@@ -147,7 +147,7 @@ public class Raven {
 
     /**
      * Sends an exception (or throwable) to the Sentry server.
-     *
+     * <p>
      * The exception will be logged at the {@link Event.Level#ERROR} level.
      *
      * @param throwable exception to send to Sentry.
@@ -246,7 +246,7 @@ public class Raven {
 
     /**
      * Sends an exception (or throwable) to the Sentry server using the statically stored Raven instance.
-     *
+     * <p>
      * The exception will be logged at the {@link Event.Level#ERROR} level.
      *
      * @param throwable exception to send to Sentry.
@@ -258,7 +258,7 @@ public class Raven {
 
     /**
      * Sends a message to the Sentry server using the statically stored Raven instance.
-     *
+     * <p>
      * The message will be logged at the {@link Event.Level#INFO} level.
      *
      * @param message message to send to Sentry.

--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -1,5 +1,4 @@
 package com.getsentry.raven;
-
 import com.getsentry.raven.connection.Connection;
 import com.getsentry.raven.environment.RavenEnvironment;
 import com.getsentry.raven.event.Event;
@@ -8,7 +7,6 @@ import com.getsentry.raven.event.helper.EventBuilderHelper;
 import com.getsentry.raven.event.interfaces.ExceptionInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 /**
  * Raven is a client for Sentry allowing to send an {@link Event} that will be processed and sent to a Sentry server.
  * <p>
@@ -32,11 +29,6 @@ public class Raven {
      */
     private static volatile Raven stored = null;
     /**
-     * The underlying {@link Connection} to use for sending events to Sentry.
-     */
-    private volatile Connection connection;
-
-    /**
      * Thread local set of active {@link Raven} objects. Note that an {@link IdentityHashMap}
      * is used instead of a Set because there is no identity-set in the Java
      * standard library.
@@ -48,8 +40,13 @@ public class Raven {
      * instances globally, without passing instances all the way down their
      * stacks. See {@link com.getsentry.raven.event.Breadcrumbs} for an example of how this may be used.
      */
-    private static Map<Raven, Raven> instances = Collections.synchronizedMap(new IdentityHashMap<Raven, Raven>());
-
+    //CHECKSTYLE.OFF: ConstantName
+    private static final Map<Raven, Raven> instances = Collections.synchronizedMap(new IdentityHashMap<Raven, Raven>());
+    //CHECKSTYLE.ON: ConstantName
+    /**
+     * The underlying {@link Connection} to use for sending events to Sentry.
+     */
+    private volatile Connection connection;
     /**
      * Set of {@link EventBuilderHelper}s. Note that we wrap a {@link ConcurrentHashMap} because there
      * isn't a concurrent set in the standard library.
@@ -62,7 +59,6 @@ public class Raven {
             return new RavenContext();
         }
     };
-
     /**
      * Constructs a Raven instance.
      *
@@ -77,7 +73,6 @@ public class Raven {
         stored = this;
         instances.put(this, this);
     }
-
     /**
      * Constructs a Raven instance using the provided connection.
      *
@@ -91,7 +86,6 @@ public class Raven {
         stored = this;
         instances.put(this, this);
     }
-
     /**
      * Runs the {@link EventBuilderHelper} against the {@link EventBuilder} to obtain additional information with a
      * MDC-like system.
@@ -103,7 +97,6 @@ public class Raven {
             builderHelper.helpBuildingEvent(eventBuilder);
         }
     }
-
     /**
      * Sends a built {@link Event} to the Sentry server.
      *
@@ -118,7 +111,6 @@ public class Raven {
             getContext().setLastEventId(event.getId());
         }
     }
-
     /**
      * Builds and sends an {@link Event} to the Sentry server.
      *
@@ -129,7 +121,6 @@ public class Raven {
         Event event = eventBuilder.build();
         sendEvent(event);
     }
-
     /**
      * Sends a message to the Sentry server.
      * <p>
@@ -144,7 +135,6 @@ public class Raven {
         Event event = eventBuilder.build();
         sendEvent(event);
     }
-
     /**
      * Sends an exception (or throwable) to the Sentry server.
      * <p>
@@ -160,7 +150,6 @@ public class Raven {
         Event event = eventBuilder.build();
         sendEvent(event);
     }
-
     /**
      * Removes a builder helper.
      *
@@ -170,7 +159,6 @@ public class Raven {
         logger.debug("Removing '{}' from the list of builder helpers.", builderHelper);
         builderHelpers.remove(builderHelper);
     }
-
     /**
      * Adds a builder helper.
      *
@@ -180,11 +168,9 @@ public class Raven {
         logger.debug("Adding '{}' to the list of builder helpers.", builderHelper);
         builderHelpers.add(builderHelper);
     }
-
     public Set<EventBuilderHelper> getBuilderHelpers() {
         return Collections.unmodifiableSet(builderHelpers);
     }
-
     /**
      * Closes the connection for the Raven instance.
      */
@@ -196,15 +182,12 @@ public class Raven {
             throw new RuntimeException("Couldn't close the Raven connection", e);
         }
     }
-
     public void setConnection(Connection connection) {
         this.connection = connection;
     }
-
     public RavenContext getContext() {
         return context.get();
     }
-
     @Override
     public String toString() {
         return "Raven{"
@@ -212,11 +195,9 @@ public class Raven {
                 + ", connection=" + connection
                 + '}';
     }
-
     // --------------------------------------------------------
     // Static helper methods follow
     // --------------------------------------------------------
-
     /**
      * Returns the last statically stored Raven instance or null if one has
      * never been stored.
@@ -226,14 +207,12 @@ public class Raven {
     public static Raven getStoredInstance() {
         return stored;
     }
-
     private static void verifyStoredInstance() {
         if (stored == null) {
             throw new NullPointerException("No stored Raven instance is available to use."
                 + " You must construct a Raven instance before using the static Raven methods.");
         }
     }
-
     /**
      * Send an Event using the statically stored Raven instance.
      *
@@ -243,7 +222,6 @@ public class Raven {
         verifyStoredInstance();
         getStoredInstance().sendEvent(event);
     }
-
     /**
      * Sends an exception (or throwable) to the Sentry server using the statically stored Raven instance.
      * <p>
@@ -255,7 +233,6 @@ public class Raven {
         verifyStoredInstance();
         getStoredInstance().sendException(throwable);
     }
-
     /**
      * Sends a message to the Sentry server using the statically stored Raven instance.
      * <p>
@@ -267,7 +244,6 @@ public class Raven {
         verifyStoredInstance();
         getStoredInstance().sendMessage(message);
     }
-
     /**
      * Builds and sends an {@link Event} to the Sentry server using the statically stored Raven instance.
      *
@@ -277,15 +253,16 @@ public class Raven {
         verifyStoredInstance();
         getStoredInstance().sendEvent(eventBuilder);
     }
-
     /**
-     * Returns any currently active {@link Raven} instances (Active instances are instances on which close has not been called).
+     * Returns any currently active {@link Raven} instances.
+     *
+     * Active instances are instances on which close has not been called.
+     *
      * @return List of active Raven instances
      */
     public static List<Raven> getInstances() {
         return new ArrayList<>(instances.keySet());
     }
-
     /**
      * Returns any active {@link RavenContext}s.
      * @return List of active RavenContext instances
@@ -297,5 +274,4 @@ public class Raven {
         }
         return contexts;
     }
-
 }

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -15,29 +15,7 @@ import java.util.UUID;
  * {@link Breadcrumb}s) so that data may be collected in different parts
  * of an application and then sent together when an exception occurs.
  */
-public class RavenContext implements AutoCloseable {
-
-    /**
-     * Thread local set of active context objects. Note that an {@link IdentityHashMap}
-     * is used instead of a Set because there is no identity-set in the Java
-     * standard library.
-     *
-     * A set of active contexts is required in order to support running multiple Raven
-     * clients within a single process. In *most* cases this set will contain a single
-     * active context object.
-     *
-     * This must be static and {@link ThreadLocal} so that users can retrieve any active
-     * context objects globally, without passing context objects all the way down their
-     * stacks. See {@link com.getsentry.raven.event.Breadcrumbs} for an example of how this may be used.
-     */
-    private static ThreadLocal<IdentityHashMap<RavenContext, RavenContext>> activeContexts =
-        new ThreadLocal<IdentityHashMap<RavenContext, RavenContext>>() {
-            @Override
-            protected IdentityHashMap<RavenContext, RavenContext> initialValue() {
-                return new IdentityHashMap<>();
-            }
-    };
-
+public class RavenContext {
     /**
      * The number of {@link Breadcrumb}s to keep in the ring buffer by default.
      */
@@ -67,45 +45,11 @@ public class RavenContext implements AutoCloseable {
     }
 
     /**
-     * Add this context to the active contexts for this thread.
-     */
-    public void activate() {
-        activeContexts.get().put(this, this);
-    }
-
-    /**
-     * Remove this context from the active contexts for this thread.
-     */
-    public void deactivate() {
-        activeContexts.get().remove(this);
-    }
-
-    /**
      * Clear state from this context.
      */
     public void clear() {
         breadcrumbs.clear();
         lastEventId = null;
-    }
-
-    /**
-     * Calls deactivate, used by try-with-resources ({@link AutoCloseable}).
-     */
-    @Override
-    public void close() {
-        deactivate();
-    }
-
-    /**
-     * Returns all active contexts for the current thread.
-     *
-     * @return List of active {@link RavenContext} objects.
-     */
-    public static List<RavenContext> getActiveContexts() {
-        Collection<RavenContext> ravenContexts = activeContexts.get().values();
-        List<RavenContext> list = new ArrayList<>(ravenContexts.size());
-        list.addAll(ravenContexts);
-        return list;
     }
 
     /**

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -3,11 +3,7 @@ package com.getsentry.raven;
 import com.getsentry.raven.event.Breadcrumb;
 import com.getsentry.raven.util.CircularFifoQueue;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.UUID;
 
 /**

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumbs.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumbs.java
@@ -1,5 +1,6 @@
 package com.getsentry.raven.event;
 
+import com.getsentry.raven.Raven;
 import com.getsentry.raven.RavenContext;
 
 /**
@@ -20,7 +21,7 @@ public final class Breadcrumbs {
      * @param breadcrumb Breadcrumb to record
      */
     public static void record(Breadcrumb breadcrumb) {
-        for (RavenContext context : RavenContext.getActiveContexts()) {
+        for (RavenContext context : Raven.getContexts()) {
             context.recordBreadcrumb(breadcrumb);
         }
     }

--- a/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
+++ b/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
@@ -29,7 +29,7 @@ public class RavenServletRequestListener implements ServletRequestListener {
         THREAD_REQUEST.remove();
 
         try {
-            for(RavenContext context : Raven.getContexts()){
+            for (RavenContext context : Raven.getContexts()) {
                 context.clear();
             }
         } catch (Exception e) {

--- a/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
+++ b/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
@@ -1,6 +1,7 @@
 package com.getsentry.raven.servlet;
 
 import com.getsentry.raven.Raven;
+import com.getsentry.raven.RavenContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,9 +29,8 @@ public class RavenServletRequestListener implements ServletRequestListener {
         THREAD_REQUEST.remove();
 
         try {
-            Raven raven = Raven.getStoredInstance();
-            if (raven != null) {
-                raven.getContext().clear();
+            for(RavenContext context : Raven.getContexts()){
+                context.clear();
             }
         } catch (Exception e) {
             logger.error("Error clearing RavenContext state.", e);

--- a/raven/src/test/java/com/getsentry/raven/RavenContextTest.java
+++ b/raven/src/test/java/com/getsentry/raven/RavenContextTest.java
@@ -15,28 +15,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 @Test(singleThreaded = true)
 public class RavenContextTest {
-
-    @Test
-    public void testActivateDeactivate() {
-        for (RavenContext context : RavenContext.getActiveContexts()) {
-            context.deactivate();
-        }
-
-        RavenContext context = new RavenContext();
-
-        assertThat(RavenContext.getActiveContexts(), emptyCollectionOf(RavenContext.class));
-
-        context.activate();
-
-        List<RavenContext> match = new ArrayList<>(1);
-        match.add(context);
-        assertThat(RavenContext.getActiveContexts(), equalTo(match));
-
-        context.deactivate();
-
-        assertThat(RavenContext.getActiveContexts(), emptyCollectionOf(RavenContext.class));
-    }
-
+    
     @Test
     public void testBreadcrumbs() {
         RavenContext context = new RavenContext();

--- a/raven/src/test/java/com/getsentry/raven/connection/EventSendFailureCallbackTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/EventSendFailureCallbackTest.java
@@ -15,13 +15,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EventSendFailureCallbackTest {
 
-    @AfterMethod
-    private void afterMethod() {
-        for (RavenContext ctx : RavenContext.getActiveContexts()) {
-            ctx.deactivate();
-        }
-    }
-
     @Test
     public void testSimpleCallback() {
         final AtomicBoolean flag = new AtomicBoolean(false);

--- a/raven/src/test/java/com/getsentry/raven/event/helper/ContextBuilderHelperTest.java
+++ b/raven/src/test/java/com/getsentry/raven/event/helper/ContextBuilderHelperTest.java
@@ -1,0 +1,57 @@
+package com.getsentry.raven.event.helper;
+
+import com.getsentry.raven.Raven;
+import com.getsentry.raven.connection.Connection;
+import com.getsentry.raven.event.Breadcrumb;
+import com.getsentry.raven.event.BreadcrumbBuilder;
+import com.getsentry.raven.event.Breadcrumbs;
+import com.getsentry.raven.event.Event;
+import com.getsentry.raven.event.EventBuilder;
+import com.getsentry.raven.event.helper.ContextBuilderHelper;
+import com.getsentry.raven.event.helper.EventBuilderHelper;
+import mockit.Injectable;
+import mockit.Tested;
+import mockit.Verifications;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * Created by matjaz on 1/31/17.
+ */
+public class ContextBuilderHelperTest {
+
+    @Tested
+    private Raven raven = null;
+
+    @Injectable
+    private Connection mockConnection = null;
+
+    @Test
+    public void testBreadcrumbsPropagation() {
+        Breadcrumb breadcrumb = new BreadcrumbBuilder()
+                .setCategory("myCat")
+                .setLevel("ERROR")
+                .setMessage("Message")
+                .build();
+        final List<Breadcrumb> match = new ArrayList<>();
+        raven.addBuilderHelper(new ContextBuilderHelper(raven));
+        Breadcrumbs.record(breadcrumb);
+        assertThat(raven, equalTo(Raven.getStoredInstance()));
+        raven.sendEvent(new EventBuilder()
+                .withMessage("Some random message")
+                .withLevel(Event.Level.INFO));
+
+        match.add(breadcrumb);
+        new Verifications() {{
+            Event event;
+            mockConnection.send(event = withCapture());
+
+            assertThat(event.getBreadcrumbs(), equalTo(match));
+        }};
+    }
+}


### PR DESCRIPTION
This is a fairly large proposal for the change of how instances of RavenContext are kept and accessed.

Disclaimer: I have also been unable to find any documentation pertaining to the feature and its use, so I apologize for any misunderstanding on my part.

The required functionality (please correct me if I am wrong):
* Using multiple Raven instances should be possible, as such one context per thread per Raven instance should be accessible
* The functionality should be unchanged in case one instance if being used
* Static helpers such as "Breadcrumbs" should set data on all RavenContext instances that are active
* The RavenServletRequestListener should clear all Raven contexts when a request is complete.

Some rationale about the changes:

I wrote a test to test the functionality and I could not make it "work"
```java
public class BreadcrumbsTest {

    @Tested
    private Raven raven = null;
    @Injectable
    private Connection mockConnection = null;
    @Injectable
    private Event mockEvent = null;
    @Injectable
    private EventBuilderHelper mockEventBuilderHelper = null;

    @Test
    public void testBreadcrumbsPropagation() {
        Breadcrumb breadcrumb = new BreadcrumbBuilder()
                .setCategory("myCat")
                .setLevel("ERROR")
                .setMessage("Message")
                .build();
        final List<Breadcrumb> match = new ArrayList<>();
        try(RavenContext context = new RavenContext() ){
            context.activate();
            //raven.getContext();
            raven.addBuilderHelper(new ContextBuilderHelper(raven));
            Breadcrumbs.record(breadcrumb);
            assertThat(raven, equalTo(Raven.getStoredInstance()));
            Raven.getStoredInstance().sendEvent(new EventBuilder()
                    .withMessage("Some random message")
                    .withLevel(Event.Level.INFO));
            // There is an event in the context, but none in the event as there are two stores....
            assertThat(context.getBreadcrumbs().next(), equalTo(breadcrumb));

        }
        match.add(breadcrumb);
        new Verifications() {{
            Event event;
            mockConnection.send(event = withCapture());

            assertThat(event.getBreadcrumbs(), equalTo(match)) ;
        }};
    }
}
```

In case of an externally provided context (and created in a try-with-resources block) the breadcrumbs would not actually be propagated to the event. Note the commented out ```raven.getContext();``` line, which actually makes the test pass, but highlights the difference in instances that exist. 

I was also quite confused with the implementation of ```AutoCloseable``` on the context, as this implies using try-with-resources, but I cannot see any way of associating such a context with a Raven instance. 