### PR TITLE
User in RavenContext

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -1,6 +1,7 @@
 package com.getsentry.raven;
 
 import com.getsentry.raven.event.Breadcrumb;
+import com.getsentry.raven.event.User;
 import com.getsentry.raven.util.CircularFifoQueue;
 
 import java.util.ArrayList;
@@ -50,6 +51,9 @@ public class RavenContext implements AutoCloseable {
      */
     private CircularFifoQueue<Breadcrumb> breadcrumbs;
 
+
+    private User user;
+
     /**
      * Create a new (empty) RavenContext object with the default Breadcrumb limit.
      */
@@ -86,6 +90,7 @@ public class RavenContext implements AutoCloseable {
     public void clear() {
         breadcrumbs.clear();
         lastEventId = null;
+        user = null;
     }
 
     /**
@@ -146,5 +151,17 @@ public class RavenContext implements AutoCloseable {
      */
     public UUID getLastEventId() {
         return lastEventId;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public void clearUser() {
+        this.user = null;
+    }
+
+    public User getUser() {
+        return user;
     }
 }

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -34,11 +34,14 @@ public class RavenContext implements AutoCloseable {
                 return new IdentityHashMap<>();
             }
     };
+
     /**
      * The number of {@link Breadcrumb}s to keep in the ring buffer by default.
      */
     private static final int DEFAULT_BREADCRUMB_LIMIT = 100;
+
     private UUID lastEventId;
+
     /**
      * Ring buffer of {@link Breadcrumb} objects.
      */
@@ -58,18 +61,21 @@ public class RavenContext implements AutoCloseable {
     public RavenContext(int breadcrumbLimit) {
         breadcrumbs = new CircularFifoQueue<>(breadcrumbLimit);
     }
+
     /**
      * Add this context to the active contexts for this thread.
      */
     public void activate() {
         activeContexts.get().put(this, this);
     }
+
     /**
      * Remove this context from the active contexts for this thread.
      */
     public void deactivate() {
         activeContexts.get().remove(this);
     }
+
     /**
      * Clear state from this context.
      */
@@ -78,6 +84,7 @@ public class RavenContext implements AutoCloseable {
         lastEventId = null;
         user = null;
     }
+
     /**
      * Calls deactivate, used by try-with-resources ({@link AutoCloseable}).
      */
@@ -85,6 +92,7 @@ public class RavenContext implements AutoCloseable {
     public void close() {
         deactivate();
     }
+
     /**
      * Returns all active contexts for the current thread.
      *
@@ -96,6 +104,7 @@ public class RavenContext implements AutoCloseable {
         list.addAll(ravenContexts);
         return list;
     }
+
     /**
      * Return {@link Breadcrumb}s attached to this RavenContext.
      *
@@ -104,6 +113,7 @@ public class RavenContext implements AutoCloseable {
     public Iterator<Breadcrumb> getBreadcrumbs() {
         return breadcrumbs.iterator();
     }
+
     /**
      * Record a single {@link Breadcrumb} into this context.
      *
@@ -112,6 +122,7 @@ public class RavenContext implements AutoCloseable {
     public void recordBreadcrumb(Breadcrumb breadcrumb) {
         breadcrumbs.add(breadcrumb);
     }
+
     /**
      * Store the UUID of the last sent event by this thread, useful for handling user feedback.
      *
@@ -120,6 +131,7 @@ public class RavenContext implements AutoCloseable {
     public void setLastEventId(UUID id) {
         lastEventId = id;
     }
+
     /**
      * Get the UUID of the last event sent by this thread, useful for handling user feedback.
      *

--- a/raven/src/main/java/com/getsentry/raven/RavenContext.java
+++ b/raven/src/main/java/com/getsentry/raven/RavenContext.java
@@ -1,23 +1,19 @@
 package com.getsentry.raven;
-
 import com.getsentry.raven.event.Breadcrumb;
 import com.getsentry.raven.event.User;
 import com.getsentry.raven.util.CircularFifoQueue;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-
 /**
  * RavenContext is used to hold {@link ThreadLocal} context data (such as
  * {@link Breadcrumb}s) so that data may be collected in different parts
  * of an application and then sent together when an exception occurs.
  */
 public class RavenContext implements AutoCloseable {
-
     /**
      * Thread local set of active context objects. Note that an {@link IdentityHashMap}
      * is used instead of a Set because there is no identity-set in the Java
@@ -38,29 +34,22 @@ public class RavenContext implements AutoCloseable {
                 return new IdentityHashMap<>();
             }
     };
-
     /**
      * The number of {@link Breadcrumb}s to keep in the ring buffer by default.
      */
     private static final int DEFAULT_BREADCRUMB_LIMIT = 100;
-
     private UUID lastEventId;
-
     /**
      * Ring buffer of {@link Breadcrumb} objects.
      */
     private CircularFifoQueue<Breadcrumb> breadcrumbs;
-
-
     private User user;
-
     /**
      * Create a new (empty) RavenContext object with the default Breadcrumb limit.
      */
     public RavenContext() {
         this(DEFAULT_BREADCRUMB_LIMIT);
     }
-
     /**
      * Create a new (empty) RavenContext object with the specified Breadcrumb limit.
      *
@@ -69,21 +58,18 @@ public class RavenContext implements AutoCloseable {
     public RavenContext(int breadcrumbLimit) {
         breadcrumbs = new CircularFifoQueue<>(breadcrumbLimit);
     }
-
     /**
      * Add this context to the active contexts for this thread.
      */
     public void activate() {
         activeContexts.get().put(this, this);
     }
-
     /**
      * Remove this context from the active contexts for this thread.
      */
     public void deactivate() {
         activeContexts.get().remove(this);
     }
-
     /**
      * Clear state from this context.
      */
@@ -92,7 +78,6 @@ public class RavenContext implements AutoCloseable {
         lastEventId = null;
         user = null;
     }
-
     /**
      * Calls deactivate, used by try-with-resources ({@link AutoCloseable}).
      */
@@ -100,7 +85,6 @@ public class RavenContext implements AutoCloseable {
     public void close() {
         deactivate();
     }
-
     /**
      * Returns all active contexts for the current thread.
      *
@@ -112,7 +96,6 @@ public class RavenContext implements AutoCloseable {
         list.addAll(ravenContexts);
         return list;
     }
-
     /**
      * Return {@link Breadcrumb}s attached to this RavenContext.
      *
@@ -121,7 +104,6 @@ public class RavenContext implements AutoCloseable {
     public Iterator<Breadcrumb> getBreadcrumbs() {
         return breadcrumbs.iterator();
     }
-
     /**
      * Record a single {@link Breadcrumb} into this context.
      *
@@ -130,7 +112,6 @@ public class RavenContext implements AutoCloseable {
     public void recordBreadcrumb(Breadcrumb breadcrumb) {
         breadcrumbs.add(breadcrumb);
     }
-
     /**
      * Store the UUID of the last sent event by this thread, useful for handling user feedback.
      *
@@ -139,7 +120,6 @@ public class RavenContext implements AutoCloseable {
     public void setLastEventId(UUID id) {
         lastEventId = id;
     }
-
     /**
      * Get the UUID of the last event sent by this thread, useful for handling user feedback.
      *
@@ -152,15 +132,24 @@ public class RavenContext implements AutoCloseable {
     public UUID getLastEventId() {
         return lastEventId;
     }
-
+    /**
+     * Store the current user in the context.
+     * @param user User
+     */
     public void setUser(User user) {
         this.user = user;
     }
-
+    /**
+     * Clears the current user set on this context.
+     */
     public void clearUser() {
         this.user = null;
     }
 
+    /**
+     * Gets the current user from the context.
+     * @return User
+     */
     public User getUser() {
         return user;
     }

--- a/raven/src/main/java/com/getsentry/raven/event/User.java
+++ b/raven/src/main/java/com/getsentry/raven/event/User.java
@@ -1,6 +1,5 @@
 package com.getsentry.raven.event;
 
-import com.getsentry.raven.event.interfaces.UserInterface;
 
 /**
  * An object that represents a user. This will usually
@@ -8,8 +7,13 @@ import com.getsentry.raven.event.interfaces.UserInterface;
  */
 public class User {
 
+    private final String id;
+    private final String username;
+    private final String ipAddress;
+    private final String email;
+
     /**
-     * Create an immutable User object
+     * Create an immutable User object.
      *
      * @param id        String (optional)
      * @param username  String (optional)
@@ -22,11 +26,6 @@ public class User {
         this.ipAddress = ipAddress;
         this.email = email;
     }
-
-    private final String id;
-    private final String username;
-    private final String ipAddress;
-    private final String email;
 
     public String getId() {
         return id;

--- a/raven/src/main/java/com/getsentry/raven/event/User.java
+++ b/raven/src/main/java/com/getsentry/raven/event/User.java
@@ -1,0 +1,47 @@
+package com.getsentry.raven.event;
+
+import com.getsentry.raven.event.interfaces.UserInterface;
+
+/**
+ * An object that represents a user. This will usually
+ * be the user for the current thread if supplied.
+ */
+public class User {
+
+    /**
+     * Create an immutable User object
+     *
+     * @param id        String (optional)
+     * @param username  String (optional)
+     * @param ipAddress String (optional)
+     * @param email     String (optional)
+     */
+    public User(String id, String username, String ipAddress, String email) {
+        this.id = id;
+        this.username = username;
+        this.ipAddress = ipAddress;
+        this.email = email;
+    }
+
+    private final String id;
+    private final String username;
+    private final String ipAddress;
+    private final String email;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+}

--- a/raven/src/main/java/com/getsentry/raven/event/UserBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/UserBuilder.java
@@ -12,44 +12,44 @@ public class UserBuilder {
     /**
      * Sets the Id for the user.
      *
-     * @param id String
+     * @param value String
      * @return current instance of UserBuilder
      */
-    public UserBuilder setId(String id) {
-        this.id = id;
+    public UserBuilder setId(String value) {
+        this.id = value;
         return this;
     }
 
     /**
      * Sets the username for the user.
      *
-     * @param username String
+     * @param value String
      * @return current instance of UserBuilder
      */
-    public UserBuilder setUsername(String username) {
-        this.username = username;
+    public UserBuilder setUsername(String value) {
+        this.username = value;
         return this;
     }
 
     /**
      * Sets the ipAddress for the user.
      *
-     * @param ipAddress String
+     * @param value String
      * @return current instance of UserBuilder
      */
-    public UserBuilder setIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
+    public UserBuilder setIpAddress(String value) {
+        this.ipAddress = value;
         return this;
     }
 
     /**
      * Sets the email for the user.
      *
-     * @param email String
+     * @param value String
      * @return current instance of UserBuilder
      */
-    public UserBuilder setEmail(String email) {
-        this.email = email;
+    public UserBuilder setEmail(String value) {
+        this.email = value;
         return this;
     }
 

--- a/raven/src/main/java/com/getsentry/raven/event/UserBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/UserBuilder.java
@@ -1,0 +1,64 @@
+package com.getsentry.raven.event;
+
+/**
+ * Builder to assist with the creation of {@link User}s.
+ */
+public class UserBuilder {
+    private String id;
+    private String username;
+    private String ipAddress;
+    private String email;
+
+    /**
+     * Sets the Id for the user.
+     *
+     * @param id String
+     * @return current instance of UserBuilder
+     */
+    public UserBuilder setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Sets the username for the user.
+     *
+     * @param username String
+     * @return current instance of UserBuilder
+     */
+    public UserBuilder setUsername(String username) {
+        this.username = username;
+        return this;
+    }
+
+    /**
+     * Sets the ipAddress for the user.
+     *
+     * @param ipAddress String
+     * @return current instance of UserBuilder
+     */
+    public UserBuilder setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+        return this;
+    }
+
+    /**
+     * Sets the email for the user.
+     *
+     * @param email String
+     * @return current instance of UserBuilder
+     */
+    public UserBuilder setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    /**
+     * Build and return the {@link User} object.
+     *
+     * @return User
+     */
+    public User build() {
+        return new User(id, username, ipAddress, email);
+    }
+}

--- a/raven/src/main/java/com/getsentry/raven/event/UserHelper.java
+++ b/raven/src/main/java/com/getsentry/raven/event/UserHelper.java
@@ -5,7 +5,7 @@ import com.getsentry.raven.RavenContext;
 /**
  * Helpers for dealing with {@link User}.
  */
-public class UserHelper {
+public final class UserHelper {
     /**
      * Private constructor because this is a utility class.
      */

--- a/raven/src/main/java/com/getsentry/raven/event/UserHelper.java
+++ b/raven/src/main/java/com/getsentry/raven/event/UserHelper.java
@@ -1,0 +1,38 @@
+package com.getsentry.raven.event;
+
+import com.getsentry.raven.RavenContext;
+
+/**
+ * Helpers for dealing with {@link User}.
+ */
+public class UserHelper {
+    /**
+     * Private constructor because this is a utility class.
+     */
+    private UserHelper() {
+
+    }
+
+
+    /**
+     * Set a {@link User} into all of this thread's active contexts.
+     *
+     * @param user Breadcrumb to record
+     */
+    public static void set(User user) {
+        for (RavenContext context : RavenContext.getActiveContexts()) {
+            context.setUser(user);
+        }
+    }
+
+    /**
+     * Clear {@link User} from all of this thread's active contexts.
+     */
+    public static void clear() {
+        for (RavenContext context : RavenContext.getActiveContexts()) {
+            context.clearUser();
+        }
+    }
+
+
+}

--- a/raven/src/main/java/com/getsentry/raven/event/helper/ContextBuilderHelper.java
+++ b/raven/src/main/java/com/getsentry/raven/event/helper/ContextBuilderHelper.java
@@ -1,8 +1,11 @@
 package com.getsentry.raven.event.helper;
 
 import com.getsentry.raven.Raven;
+import com.getsentry.raven.RavenContext;
 import com.getsentry.raven.event.Breadcrumb;
 import com.getsentry.raven.event.EventBuilder;
+import com.getsentry.raven.event.User;
+import com.getsentry.raven.event.interfaces.UserInterface;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -31,11 +34,25 @@ public class ContextBuilderHelper implements EventBuilderHelper {
     @Override
     public void helpBuildingEvent(EventBuilder eventBuilder) {
         List<Breadcrumb> breadcrumbs = new ArrayList<>();
-        Iterator<Breadcrumb> iter = raven.getContext().getBreadcrumbs();
+        RavenContext context = raven.getContext();
+        Iterator<Breadcrumb> iter = context.getBreadcrumbs();
         while (iter.hasNext()) {
             breadcrumbs.add(iter.next());
         }
         eventBuilder.withBreadcrumbs(breadcrumbs);
+
+        if (context.getUser() != null) {
+            eventBuilder.withSentryInterface(fromUser(context.getUser()));
+        }
+    }
+
+    /**
+     * Builds a {@link UserInterface} object from a {@link User} object.
+     * @param user User
+     * @return UserInterface
+     */
+    private UserInterface fromUser(User user) {
+        return new UserInterface(user.getId(), user.getUsername(), user.getIpAddress(), user.getEmail());
     }
 
 }

--- a/raven/src/test/java/com/getsentry/raven/RavenContextTest.java
+++ b/raven/src/test/java/com/getsentry/raven/RavenContextTest.java
@@ -2,6 +2,8 @@ package com.getsentry.raven;
 
 import com.getsentry.raven.event.Breadcrumb;
 import com.getsentry.raven.event.BreadcrumbBuilder;
+import com.getsentry.raven.event.User;
+import com.getsentry.raven.event.UserBuilder;
 import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
@@ -88,6 +90,22 @@ public class RavenContextTest {
         }
 
         assertThat(breadcrumbs, equalTo(breadcrumbMatch));
+
+    }
+
+    @Test
+    public void testUser() {
+        RavenContext context = new RavenContext();
+
+        User user = new UserBuilder()
+                .setEmail("test@example.com")
+                .setId("1234")
+                .setIpAddress("192.168.0.1")
+                .setUsername("testUser_123").build();
+
+        context.setUser(user);
+
+        assertThat(context.getUser(), equalTo(user));
 
     }
 

--- a/raven/src/test/java/com/getsentry/raven/event/UserTest.java
+++ b/raven/src/test/java/com/getsentry/raven/event/UserTest.java
@@ -1,0 +1,57 @@
+package com.getsentry.raven.event;
+
+import com.getsentry.raven.Raven;
+import com.getsentry.raven.connection.Connection;
+import com.getsentry.raven.event.helper.ContextBuilderHelper;
+import com.getsentry.raven.event.interfaces.SentryInterface;
+import com.getsentry.raven.event.interfaces.UserInterface;
+import mockit.Injectable;
+import mockit.Tested;
+import mockit.Verifications;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * Created by matjaz on 2/1/17.
+ */
+public class UserTest {
+    @Tested
+    private Raven raven = null;
+
+    @Injectable
+    private Connection mockConnection = null;
+
+    @Test
+    public void testUserPropagation() {
+        final User user = new UserBuilder()
+                .setEmail("test@example.com")
+                .setId("1234")
+                .setIpAddress("192.168.0.1")
+                .setUsername("testUser_123").build();
+        raven.addBuilderHelper(new ContextBuilderHelper(raven));
+        raven.getContext();
+        UserHelper.set(user);
+
+        raven.sendEvent(new EventBuilder()
+                .withMessage("Some random message")
+                .withLevel(Event.Level.INFO));
+
+
+        new Verifications() {{
+            Event event;
+            mockConnection.send(event = withCapture());
+            UserInterface userInterface = (UserInterface) event.getSentryInterfaces().get(UserInterface.USER_INTERFACE);
+            assertThat(userInterface.getId(), equalTo(user.getId()));
+            assertThat(userInterface.getEmail(), equalTo(user.getEmail()));
+            assertThat(userInterface.getIpAddress(), equalTo(user.getIpAddress()));
+            assertThat(userInterface.getUsername(), equalTo(user.getUsername()));
+        }};
+    }
+
+
+}

--- a/raven/src/test/java/com/getsentry/raven/event/UserTest.java
+++ b/raven/src/test/java/com/getsentry/raven/event/UserTest.java
@@ -3,15 +3,11 @@ package com.getsentry.raven.event;
 import com.getsentry.raven.Raven;
 import com.getsentry.raven.connection.Connection;
 import com.getsentry.raven.event.helper.ContextBuilderHelper;
-import com.getsentry.raven.event.interfaces.SentryInterface;
 import com.getsentry.raven.event.interfaces.UserInterface;
 import mockit.Injectable;
 import mockit.Tested;
 import mockit.Verifications;
 import org.testng.annotations.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;


### PR DESCRIPTION
User can be set using ```UserHelper.set(User user)``` or removed ```UserHelper.clear()```.

This PR supersedes: #292 

With this PR the changes affect all loggers. Additional tests could be added for each logger, but with the tests done in core I think this should be enough.

If a user exists in the context (it is not null) it will be sent using the UserInterface class.