### PR TITLE
Add makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ prepareChanges:
 	$(eval DASHES=$(shell python -c 'print("-" * (8 + len("$(DEV_VERSION)")))'))
 # Add new Version section to the top of the CHANGES file
 	@echo Updating CHANGES file
-	echo -e "Version $(DEV_VERSION)\n$(DASHES)\n\n- ???\n" > CHANGES.new && cat CHANGES >> CHANGES.new && mv CHANGES.new CHANGES
+	echo -e "Version $(DEV_VERSION)\n$(DASHES)\n\n-\n" > CHANGES.new && cat CHANGES >> CHANGES.new && mv CHANGES.new CHANGES
 	git add CHANGES
 	git commit -m "Bump CHANGES to $(DEV_VERSION)"
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+.PHONY: checkstyle test install clean prepare prepareDocs prepareMvn prepareChanges perform
+
+MVN=mvn -e
+
+all: checkstyle test install
+
+checkstyle:
+	$(MVN) checkstyle:check
+
+test:
+	$(MVN) verify
+
+install:
+	$(MVN) install -Dcheckstyle.skip=true -DskipTests
+
+clean:
+	$(MVN) clean
+
+prepareDocs:
+# Store previously released version
+	$(eval PREVIOUS_RELEASE=$(shell grep -E "^Version" CHANGES | head -2 | tail -1 | sed -e 's/Version //'))
+	@echo Previous release: $(PREVIOUS_RELEASE)
+# Store release project version
+	$(eval RELEASE_VERSION=$(shell mvn help:evaluate -Dexpression=project.version | grep -Ev '^\[' | sed -e 's/-SNAPSHOT//'))
+	@echo This release: $(RELEASE_VERSION)
+# Fix released version in documentation
+	@echo Fixing documentation versions
+	find . -name '*.md' -or -name '*.rst' -exec sed -i -e 's/$(PREVIOUS_RELEASE)/$(RELEASE_VERSION)/g' {} \;
+# Commit documentation changes
+	@echo Committing documentation version changes
+	git commit -a -m 'Bump docs to $(RELEASE_VERSION)'
+
+prepareMvn:
+# Prepare release (interactive)
+	$(MVN) release:prepare
+
+prepareChanges:
+# Store new project version
+	$(eval DEV_VERSION=$(shell mvn help:evaluate -Dexpression=project.version | grep -Ev '^\[' | sed -e 's/-SNAPSHOT//'))
+	@echo Development version: $(DEV_VERSION)
+# Store enough dashes to go under "Version X.Y.Z", accounting for changes in the $VERSION length
+	$(eval DASHES=$(shell python -c 'print("-" * (8 + len("$(DEV_VERSION)")))'))
+# Add new Version section to the top of the CHANGES file
+	@echo Updating CHANGES file
+	echo -e "Version $(DEV_VERSION)\n$(DASHES)\n\n- ???\n" > CHANGES.new && cat CHANGES >> CHANGES.new && mv CHANGES.new CHANGES
+	git add CHANGES
+	git commit -m "Bump CHANGES to $(DEV_VERSION)"
+
+# Prepare is broken into stages because otherwise `make` will run things out of order
+prepare: prepareDocs prepareMvn prepareChanges
+
+perform:
+	$(MVN) release:perform
+
+rollback:
+	$(MVN) release:rollback


### PR DESCRIPTION
Covered all the commands I typically run.

The most complex is `prepare`, which is nice to finally have automated. I tested this a lot locally, you can do the same if you'd like -- it's best to run on a branch, and to undo it you'll have to hard reset back or at minimum delete the local tag it creates (so that it won't conflict or push to remote).

It adds 2 commits in addition to the normal `mvn` ones,

```
* a2e0ae27 - (HEAD -> makefile) Bump CHANGES to 7.8.3 Brett Hoerner (8 seconds ago)
* 0d27ea88 - [maven-release-plugin] prepare for next development iteration Brett Hoerner (10 seconds ago)
* a8330680 - (tag: v7.8.2) [maven-release-plugin] prepare release v7.8.2 Brett Hoerner (10 seconds ago)
* 33452227 - Bump docs to 7.8.2 Brett Hoerner (76 seconds ago)
```

The doc changes I used to run manually with `sed`, it looks like this:

```
33452227 - Bump docs to 7.8.2 (2 minutes ago) <Brett Hoerner>
diff --git a/docs/modules/appengine.rst b/docs/modules/appengine.rst
index aa0c6a7a..0108b537 100644
--- a/docs/modules/appengine.rst
+++ b/docs/modules/appengine.rst
@@ -25,7 +25,7 @@ If you want to use Maven you can install Raven-AppEngine as dependency:
     <dependency>
         <groupId>com.getsentry.raven</groupId>
         <artifactId>raven-appengine</artifactId>
-        <version>7.8.1</version>
+        <version>7.8.2</version>
     </dependency>
```

...and so on.

And the CHANGES one is new:

```
a2e0ae27 - (HEAD -> makefile) Bump CHANGES to 7.8.3 (26 seconds ago) <Brett Hoerner>
diff --git a/CHANGES b/CHANGES
index 40108be7..74b15f65 100644
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Version 7.8.3
+-------------
+
+- ???
+
 Version 7.8.2
 -------------
```