### PR TITLE
Update logging configuration examples to show non-Sentry appender and…

### DIFF
--- a/raven-log4j/README.md
+++ b/raven-log4j/README.md
@@ -30,27 +30,36 @@ Relies on:
 Add the `SentryAppender` to the `log4j.properties` file:
 
 ```properties
-log4j.rootLogger=WARN, SentryAppender
-log4j.appender.SentryAppender=com.getsentry.raven.log4j.SentryAppender
+# Enable the Console and Sentry appenders
+log4j.rootLogger=INFO, Console, Sentry
+
+# Configure the Console appender
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=%d{HH:mm:ss.SSS} [%t] %-5p: %m%n
+
+# Configure the Sentry appender, overriding the logging threshold to the WARN level
+log4j.appender.Sentry=com.getsentry.raven.log4j.SentryAppender
+log4j.appender.Sentry.threshold=WARN
 ```
 
-Alternatively in the `log4j.xml` file set:
+Alternatively in the `log4j.xml` file add:
 
 ```
-  <appender name="sentry" class="com.getsentry.raven.log4j.SentryAppender">
-    <filter class="org.apache.log4j.varia.LevelRangeFilter">
-      <param name="levelMin" value="WARN"/>
-    </filter>
+  <appender name="Sentry" class="com.getsentry.raven.log4j.SentryAppender">
+      <!-- Override the Sentry handler log level to WARN -->
+      <filter class="org.apache.log4j.varia.LevelRangeFilter">
+          <param name="levelMin" value="WARN"/>
+      </filter>
   </appender>
 ```
 
-You'll also need to associate the `sentry` appender with your root logger, like so:
+You'll also need to associate the `Sentry` appender with your root logger, like so:
 
 ```
-  <root>
-    <priority value="info" />
-    <appender-ref ref="my-other-appender" />
-    <appender-ref ref="sentry" />
+  <root level="INFO>
+      <!-- <appender-ref ref="OtherAppender" /> -->
+      <appender-ref ref="Sentry" />
   </root>
 ```
 
@@ -88,25 +97,34 @@ Configuration parameters follow:
 | `SENTRY_TAGS` | `sentry.tags` | `tag1:value1,tag2:value2` | Optional, provide tags |
 | `SENTRY_EXTRA_TAGS` | `sentry.extratags` | `foo,bar,baz` | Optional, provide tag names to be extracted from MDC when using SLF4J |
 
-#### Configuration via `log4j.properties`
+#### Configuration via `log4j.properties` (or `log4j.xml`)
 
-You can also configure everything statically within the `log4j.properties` file
-itself. This is less flexible because it's harder to change when you run
+You can also configure everything statically within the `log4j.properties` (or `log4j.xml`)
+file itself. This is less flexible because it's harder to change when you run
 your application in different environments.
 
 ```properties
-log4j.rootLogger=WARN, SentryAppender
-log4j.appender.SentryAppender=com.getsentry.raven.log4j.SentryAppender
+# Enable the Console and Sentry appenders
+log4j.rootLogger=INFO, Console, Sentry
+
+# Configure the Console appender
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+
+# Configure the Sentry appender, overriding the logging threshold to the WARN level
+log4j.appender.Sentry=com.getsentry.raven.log4j.SentryAppender
+log4j.appender.Sentry.threshold=WARN
+
+# Set Sentry DSN
 log4j.appender.SentryAppender.dsn=https://host:port/1?options
-// Optional, provide release version of your application
+# Optional, provide release version of your application
 log4j.appender.SentryAppender.release=1.0.0
-// Optional, provide environment your application is running in
+# Optional, provide environment your application is running in
 log4j.appender.SentryAppender.environment=production
-// Optional, override the server name (rather than looking it up dynamically)
+# Optional, override the server name (rather than looking it up dynamically)
 log4j.appender.SentryAppender.serverName=server1
 # Optional, select the ravenFactory class
-#log4j.appender.SentryAppender.ravenFactory=com.foo.RavenFactory
-// Optional, provide tags
+log4j.appender.SentryAppender.ravenFactory=com.foo.RavenFactory
+# Optional, provide tags
 log4j.appender.SentryAppender.tags=tag1:value1,tag2:value2
 # Optional, provide tag names to be extracted from MDC when using SLF4J
 log4j.appender.SentryAppender.extraTags=foo,bar,baz

--- a/raven-log4j2/README.md
+++ b/raven-log4j2/README.md
@@ -35,12 +35,17 @@ Add the `SentryAppender` to your `log4j2.xml` file:
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration status="warn" packages="org.apache.logging.log4j.core,com.getsentry.raven.log4j2">
     <appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+        </Console>
+
         <Raven name="Sentry" />
     </appenders>
 
     <loggers>
-        <root level="all">
-            <appender-ref ref="Sentry"/>
+        <root level="INFO">
+            <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" level="WARN" />
         </root>
     </loggers>
 </configuration>
@@ -90,54 +95,31 @@ your application in different environments.
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration status="warn" packages="org.apache.logging.log4j.core,com.getsentry.raven.log4j2">
     <appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+        </Console>
+
         <Raven name="Sentry">
-            <dsn>
-                https://host:port/1?options
-            </dsn>
-            <!--
-                Optional, provide release version of your application
-            -->
-            <release>
-                1.0.0
-            </release>
-            <!--
-                Optional, provide environment your application is running in
-            -->
-            <environment>
-                production
-            </environment>
-            <!--
-                Optional, override the server name (rather than looking it up dynamically)
-            -->
-            <serverName>
-                server1
-            </serverName>
-            <!--
-                Optional, select the ravenFactory class
-            -->
-            <!--
-            <ravenFactory>
-                com.foo.RavenFactory
-            </ravenFactory>
-            -->
-            <!--
-                Optional, provide tags
-            -->
-            <tags>
-                tag1:value1,tag2:value2
-            </tags>
-            <!--
-                Optional, provide tag names to be extracted from MDC when using SLF4J
-            -->
-            <extraTags>
-                foo,bar,baz
-            </extraTags>
+            <dsn>https://host:port/1?options</dsn>
+            <!-- Optional, provide release version of your application -->
+            <release>1.0.0</release>
+            <!-- Optional, provide environment your application is running in -->
+            <environment>production</environment>
+            <!-- Optional, override the server name (rather than looking it up dynamically) -->
+            <serverName>server1</serverName>
+            <!-- Optional, select the ravenFactory class -->
+            <ravenFactory>com.foo.RavenFactory</ravenFactory>
+            <!-- Optional, provide tags -->
+            <tags>tag1:value1,tag2:value2</tags>
+            <!-- Optional, provide tag names to be extracted from MDC when using SLF4J -->
+            <extraTags>foo,bar,baz</extraTags>
         </Raven>
     </appenders>
 
     <loggers>
-        <root level="all">
-            <appender-ref ref="Sentry"/>
+        <root level="INFO">
+            <appender-ref ref="Console" />
+            <appender-ref ref="Sentry" level="WARN" />
         </root>
     </loggers>
 </configuration>

--- a/raven-logback/README.md
+++ b/raven-logback/README.md
@@ -31,8 +31,20 @@ Add the `SentryAppender` to your `logback.xml` file:
 
 ```xml
 <configuration>
-    <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender" />
-    <root level="warn">
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="Console" />
         <appender-ref ref="Sentry"/>
     </root>
 </configuration>
@@ -80,7 +92,18 @@ your application in different environments.
 
 ```xml
 <configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+
+        <!-- Set Sentry DSN -->
         <dsn>https://host:port/1?options</dsn>
         <!-- Optional, provide release version of your application -->
         <release>1.0.0</release>
@@ -95,7 +118,9 @@ your application in different environments.
         <!-- Optional, provide tag names to be extracted from MDC when using SLF4J -->
         <extraTags>foo,bar,baz</extraTags>
     </appender>
-    <root level="warn">
+
+    <root level="INFO">
+        <appender-ref ref="Console" />
         <appender-ref ref="Sentry"/>
     </root>
 </configuration>

--- a/raven/README.md
+++ b/raven/README.md
@@ -32,8 +32,14 @@ Relies on:
 Add the `SentryHandler` to the `logging.properties` file:
 
 ```properties
-.level=WARNING
-handlers=com.getsentry.raven.jul.SentryHandler
+# Enable the Console and Sentry handlers
+handlers=java.util.logging.ConsoleHandler,com.getsentry.raven.jul.SentryHandler
+
+# Set the default log level to INFO
+.level=INFO
+
+# Override the Sentry handler log level to WARNING
+com.getsentry.raven.jul.SentryHandler.level=WARNING
 ```
 
 When starting your application, add the `java.util.logging.config.file` to the
@@ -82,8 +88,16 @@ itself. This is less flexible because it's harder to change when you run
 your application in different environments.
 
 ```properties
-.level=WARNING
-handlers=com.getsentry.raven.jul.SentryHandler
+# Enable the Console and Sentry handlers
+handlers=java.util.logging.ConsoleHandler,com.getsentry.raven.jul.SentryHandler
+
+# Set the default log level to INFO
+.level=INFO
+
+# Override the Sentry handler log level to WARNING
+com.getsentry.raven.jul.SentryHandler.level=WARNING
+
+# Set Sentry DSN
 com.getsentry.raven.jul.SentryHandler.dsn=https://host:port/1?options
 # Optional, provide tags
 com.getsentry.raven.jul.SentryHandler.tags=tag1:value1,tag2:value2


### PR DESCRIPTION
… set Sentry to WARN level.

This is related to https://github.com/getsentry/raven-java-examples/pull/7

I wanted all of our logging examples to,

1. Show another appender (Console) set to a different Level (INFO).
2. Configure Sentry to WARN

A lot of people seem to copy/paste our examples literally, and some of our examples would set Sentry to DEBUG or worse. :(