### PR TITLE
Change lockdown to drop Events, allow subclasses to hint lockdown tim…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ Version 7.8.3
 -------------
 
 - Add User to RavenContext and ContextBuilderHelper. (thanks mpecan)
+- Drop Events when the connection is locked down, users must enable buffering to attempt to resend later.
+- Respect the Sentry server's ``Retry-After`` header.
 
 Version 7.8.2
 -------------

--- a/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
@@ -2,16 +2,15 @@ package com.getsentry.raven.connection;
 
 import com.getsentry.raven.environment.RavenEnvironment;
 import com.getsentry.raven.event.Event;
+import com.getsentry.raven.time.Clock;
+import com.getsentry.raven.time.SystemClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Abstract connection to a Sentry server.
@@ -34,21 +33,32 @@ public abstract class AbstractConnection implements Connection {
      */
     public static final long DEFAULT_BASE_WAITING_TIME = TimeUnit.MILLISECONDS.toMillis(10);
     private static final Logger logger = LoggerFactory.getLogger(AbstractConnection.class);
-    private final AtomicBoolean lockdown = new AtomicBoolean();
-    private final Lock lock = new ReentrantLock();
-    private final Condition condition = lock.newCondition();
+    /**
+     * Value of the X-Sentry-Auth header.
+     */
     private final String authHeader;
     /**
-     * Maximum duration for a lockdown.
+     * Clock instance used for time, injectable for testing.
      */
-    private long maxWaitingTime = DEFAULT_MAX_WAITING_TIME;
+    private final Clock clock;
     /**
-     * Base duration for a lockdown.
-     * <p>
-     * On each attempt the time is doubled until it reaches {@link #maxWaitingTime}.
+     * Maximum duration for a lockdown, in milliseconds.
      */
-    private long baseWaitingTime = DEFAULT_BASE_WAITING_TIME;
-    private long waitingTime = baseWaitingTime;
+    private long maxLockdownWaitingTime = DEFAULT_MAX_WAITING_TIME;
+    /**
+     * Base duration for a lockdown, in milliseconds.
+     * <p>
+     * On each attempt the time is doubled until it reaches {@link #maxLockdownWaitingTime}.
+     */
+    private long baseLockdownWaitingTime = DEFAULT_BASE_WAITING_TIME;
+    /**
+     * Number of milliseconds after lockdownStartTime to lockdown for, or 0 if not currently locked down.
+     */
+    private long lockdownWaitingTime = 0;
+    /**
+     * Timestamp of when the current lockdown started, or null if not currently locked down.
+     */
+    private Date lockdownStartTime = null;
     /**
      * Set of callbacks that will be called when an exception occurs while attempting to
      * send events to the Sentry server.
@@ -62,8 +72,9 @@ public abstract class AbstractConnection implements Connection {
      * @param secretKey secret key (password) to the Sentry server.
      */
     protected AbstractConnection(String publicKey, String secretKey) {
-        eventSendFailureCallbacks = new HashSet<>();
-        authHeader = "Sentry sentry_version=" + SENTRY_PROTOCOL_VERSION + ","
+        this.clock = new SystemClock();
+        this.eventSendFailureCallbacks = new HashSet<>();
+        this.authHeader = "Sentry sentry_version=" + SENTRY_PROTOCOL_VERSION + ","
                 + "sentry_client=" + RavenEnvironment.getRavenName() + ","
                 + "sentry_key=" + publicKey + ","
                 + "sentry_secret=" + secretKey;
@@ -81,14 +92,15 @@ public abstract class AbstractConnection implements Connection {
     @Override
     public final void send(Event event) throws ConnectionException {
         try {
-            waitIfLockedDown();
+            if (isLockedDown()) {
+                logger.debug("Dropped an Event due to lockdown: {}", event);
+                return;
+            }
 
             doSend(event);
-            waitingTime = baseWaitingTime;
-        } catch (ConnectionException e) {
-            logger.warn("An exception due to the connection occurred, a lockdown will be initiated.", e);
-            lockDown();
 
+            resetLockdown();
+        } catch (ConnectionException e) {
             for (EventSendFailureCallback eventSendFailureCallback : eventSendFailureCallbacks) {
                 try {
                     eventSendFailureCallback.onFailure(event, e);
@@ -98,62 +110,42 @@ public abstract class AbstractConnection implements Connection {
                 }
             }
 
+            logger.warn("An exception due to the connection occurred, a lockdown will be initiated.", e);
+            setLockdownState(e);
+
             throw e;
         }
     }
 
-    /**
-     * Pauses the current thread if there is a lockdown.
-     */
-    private void waitIfLockedDown() {
-        while (lockdown.get()) {
-            lock.lock();
-            try {
-                if (lockdown.get()) {
-                    condition.await();
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                logger.warn("An exception occurred during the lockdown.", e);
-            } finally {
-                lock.unlock();
-            }
-        }
+    private synchronized boolean isLockedDown() {
+        return lockdownStartTime != null && (clock.millis() - lockdownStartTime.getTime()) < lockdownWaitingTime;
     }
 
-    /**
-     * Initiates a lockdown for {@link #waitingTime}ms and resume the paused threads once the lockdown ends.
-     */
-    private void lockDown() {
-        if (!lockdown.compareAndSet(false, true)) {
+    private synchronized void resetLockdown() {
+        lockdownWaitingTime = 0;
+        lockdownStartTime = null;
+    }
+
+    private synchronized void setLockdownState(ConnectionException connectionException) {
+        // If we are already in a lockdown state, don't change anything
+        if (isLockedDown()) {
             return;
         }
 
-        try {
-            logger.warn("Lockdown started for {}ms.", waitingTime);
-            Thread.sleep(waitingTime);
-
-            // Double the wait until the maximum is reached
-            if (waitingTime < maxWaitingTime) {
-                waitingTime <<= 1;
-            }
-        } catch (Exception e) {
-            logger.warn("An exception occurred during the lockdown.", e);
-        } finally {
-            lockdown.set(false);
-
-            lock.lock();
-            try {
-                condition.signalAll();
-            } finally {
-                lock.unlock();
-            }
-            logger.warn("Lockdown ended.");
+        if (connectionException.getRecommendedLockdownWaitTime() != null) {
+            lockdownWaitingTime = connectionException.getRecommendedLockdownWaitTime();
+        } else if (lockdownWaitingTime != 0) {
+            lockdownWaitingTime = lockdownWaitingTime * 2;
+        } else {
+            lockdownWaitingTime = baseLockdownWaitingTime;
         }
+
+        lockdownWaitingTime = Math.min(maxLockdownWaitingTime, lockdownWaitingTime);
+        lockdownStartTime = clock.date();
     }
 
     /**
-     * Sends an event to the sentry server.
+     * Sends an event to the Sentry server.
      *
      * @param event captured event to add in Sentry.
      * @throws ConnectionException whenever a temporary exception due to the connection happened.
@@ -161,11 +153,11 @@ public abstract class AbstractConnection implements Connection {
     protected abstract void doSend(Event event) throws ConnectionException;
 
     public void setMaxWaitingTime(long maxWaitingTime) {
-        this.maxWaitingTime = maxWaitingTime;
+        this.maxLockdownWaitingTime = maxWaitingTime;
     }
 
     public void setBaseWaitingTime(long baseWaitingTime) {
-        this.baseWaitingTime = baseWaitingTime;
+        this.baseLockdownWaitingTime = baseWaitingTime;
     }
 
     /**

--- a/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
@@ -70,7 +70,7 @@ public abstract class AbstractConnection implements Connection {
 
             doSend(event);
 
-            lockdownManager.resetLockdown();
+            lockdownManager.resetState();
         } catch (ConnectionException e) {
             for (EventSendFailureCallback eventSendFailureCallback : eventSendFailureCallbacks) {
                 try {
@@ -82,7 +82,7 @@ public abstract class AbstractConnection implements Connection {
             }
 
             logger.warn("An exception due to the connection occurred, a lockdown will be initiated.", e);
-            lockdownManager.setLockdownState(e);
+            lockdownManager.setState(e);
 
             throw e;
         }

--- a/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class AbstractConnection implements Connection {
     /**
-     * Current sentry protocol version.
+     * Current Sentry protocol version.
      */
     public static final String SENTRY_PROTOCOL_VERSION = "6";
     /**
@@ -80,7 +80,7 @@ public abstract class AbstractConnection implements Connection {
     }
 
     /**
-     * Creates an authentication header for the sentry protocol.
+     * Creates an authentication header for the Sentry protocol.
      *
      * @return an authentication header as a String.
      */

--- a/raven/src/main/java/com/getsentry/raven/connection/ConnectionException.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/ConnectionException.java
@@ -6,8 +6,14 @@ package com.getsentry.raven.connection;
  * This allows connections to know when to back off for a while.
  */
 public class ConnectionException extends RuntimeException {
+    /**
+     * Recommended duration to initiate a lockdown for, in milliseconds.
+     */
+    private Long recommendedLockdownWaitTime = null;
+
     //CHECKSTYLE.OFF: JavadocMethod
     public ConnectionException() {
+
     }
 
     public ConnectionException(String message) {
@@ -18,8 +24,17 @@ public class ConnectionException extends RuntimeException {
         super(message, cause);
     }
 
+    public ConnectionException(String message, Throwable cause, Long recommendedLockdownWaitTime) {
+        super(message, cause);
+        this.recommendedLockdownWaitTime = recommendedLockdownWaitTime;
+    }
+
     public ConnectionException(Throwable cause) {
         super(cause);
+    }
+
+    public Long getRecommendedLockdownWaitTime() {
+        return recommendedLockdownWaitTime;
     }
     //CHECKSTYLE.ON: JavadocMethod
 }

--- a/raven/src/main/java/com/getsentry/raven/connection/ConnectionException.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/ConnectionException.java
@@ -9,7 +9,7 @@ public class ConnectionException extends RuntimeException {
     /**
      * Recommended duration to initiate a lockdown for, in milliseconds.
      */
-    private Long recommendedLockdownWaitTime = null;
+    private Long recommendedLockdownTime = null;
 
     //CHECKSTYLE.OFF: JavadocMethod
     public ConnectionException() {
@@ -24,17 +24,17 @@ public class ConnectionException extends RuntimeException {
         super(message, cause);
     }
 
-    public ConnectionException(String message, Throwable cause, Long recommendedLockdownWaitTime) {
+    public ConnectionException(String message, Throwable cause, Long recommendedLockdownTime) {
         super(message, cause);
-        this.recommendedLockdownWaitTime = recommendedLockdownWaitTime;
+        this.recommendedLockdownTime = recommendedLockdownTime;
     }
 
     public ConnectionException(Throwable cause) {
         super(cause);
     }
 
-    public Long getRecommendedLockdownWaitTime() {
-        return recommendedLockdownWaitTime;
+    public Long getRecommendedLockdownTime() {
+        return recommendedLockdownTime;
     }
     //CHECKSTYLE.ON: JavadocMethod
 }

--- a/raven/src/main/java/com/getsentry/raven/connection/HttpConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/HttpConnection.java
@@ -142,7 +142,7 @@ public class HttpConnection extends AbstractConnection {
             connection.setRequestProperty(SENTRY_AUTH, getAuthHeader());
             return connection;
         } catch (IOException e) {
-            throw new IllegalStateException("Couldn't set up a connection to the sentry server.", e);
+            throw new IllegalStateException("Couldn't set up a connection to the Sentry server.", e);
         }
     }
 
@@ -166,9 +166,24 @@ public class HttpConnection extends AbstractConnection {
                 errorMessage = getErrorMessageFromStream(errorStream);
             }
             if (null == errorMessage || errorMessage.isEmpty()) {
-                errorMessage = "An exception occurred while submitting the event to the sentry server.";
+                errorMessage = "An exception occurred while submitting the event to the Sentry server.";
             }
-            throw new ConnectionException(errorMessage, e);
+
+            Long retryAfterMs = null;
+            String retryAfterHeader = connection.getHeaderField("Retry-After");
+            if (retryAfterHeader != null) {
+                // CHECKSTYLE.OFF: EmptyCatchBlock
+                try {
+                    // CHECKSTYLE.OFF: MagicNumber
+                    retryAfterMs = Long.parseLong(retryAfterHeader) * 1000; // seconds -> milliseconds
+                    // CHECKSTYLE.ON: MagicNumber
+                } catch (NumberFormatException nfe) {
+                    // noop, use default retry
+                }
+                // CHECKSTYLE.ON: EmptyCatchBlock
+            }
+
+            throw new ConnectionException(errorMessage, e, retryAfterMs);
         } finally {
             connection.disconnect();
         }

--- a/raven/src/main/java/com/getsentry/raven/connection/HttpConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/HttpConnection.java
@@ -175,7 +175,7 @@ public class HttpConnection extends AbstractConnection {
                 // CHECKSTYLE.OFF: EmptyCatchBlock
                 try {
                     // CHECKSTYLE.OFF: MagicNumber
-                    retryAfterMs = Long.parseLong(retryAfterHeader) * 1000; // seconds -> milliseconds
+                    retryAfterMs = Long.parseLong(retryAfterHeader) * 1000L; // seconds -> milliseconds
                     // CHECKSTYLE.ON: MagicNumber
                 } catch (NumberFormatException nfe) {
                     // noop, use default retry

--- a/raven/src/main/java/com/getsentry/raven/connection/LockdownManager.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/LockdownManager.java
@@ -1,0 +1,110 @@
+package com.getsentry.raven.connection;
+
+import com.getsentry.raven.time.Clock;
+import com.getsentry.raven.time.SystemClock;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Abstracts the connection lockdown logic (and state) to a single place so that
+ * it's easier to understand.
+ */
+public class LockdownManager {
+    /**
+     * Default maximum duration for a lockdown.
+     */
+    public static final long DEFAULT_MAX_LOCKDOWN_TIME = TimeUnit.MINUTES.toMillis(5);
+    /**
+     * Default base duration for a lockdown.
+     */
+    public static final long DEFAULT_BASE_LOCKDOWN_TIME = TimeUnit.SECONDS.toMillis(1);
+    /**
+     * Maximum duration for a lockdown, in milliseconds.
+     */
+    private long maxLockdownTime = DEFAULT_MAX_LOCKDOWN_TIME;
+    /**
+     * Base duration for a lockdown, in milliseconds.
+     * <p>
+     * On each attempt the time is doubled until it reaches {@link #maxLockdownTime}.
+     */
+    private long baseLockdownTime = DEFAULT_BASE_LOCKDOWN_TIME;
+    /**
+     * Number of milliseconds after lockdownStartTime to lockdown for, or 0 if not currently locked down.
+     */
+    private long lockdownTime = 0;
+    /**
+     * Timestamp of when the current lockdown started, or null if not currently locked down.
+     */
+    private Date lockdownStartTime = null;
+    /**
+     * Clock instance used for time, injectable for testing.
+     */
+    private final Clock clock;
+
+    /**
+     * Construct a LockdownManager using the default system clock.
+     */
+    public LockdownManager() {
+        this(new SystemClock());
+    }
+
+    /**
+     * Construct a LockdownManager using the provided clock.
+     *
+     * @param clock Clock object to use for lockdown logic
+     */
+    public LockdownManager(Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Returns true if the system is in a lockdown.
+     *
+     * @return true if the system is in a lockdown, otherwise false
+     */
+    public synchronized boolean isLockedDown() {
+        return lockdownStartTime != null && (clock.millis() - lockdownStartTime.getTime()) < lockdownTime;
+    }
+
+    /**
+     * Reset the lockdown state, disabling lockdown and setting the backoff time to zero.
+     */
+    public synchronized void resetLockdown() {
+        lockdownTime = 0;
+        lockdownStartTime = null;
+    }
+
+    /**
+     * Enable lockdown if it's not already enabled, using the recommended time
+     * from the provided {@link ConnectionException}, if any.
+     *
+     * @param connectionException ConnectionException to check for a recommended
+     *                            lockdown time, may be null
+     */
+    public synchronized void setLockdownState(ConnectionException connectionException) {
+        // If we are already in a lockdown state, don't change anything
+        if (isLockedDown()) {
+            return;
+        }
+
+        if (connectionException != null && connectionException.getRecommendedLockdownTime() != null) {
+            lockdownTime = connectionException.getRecommendedLockdownTime();
+        } else if (lockdownTime != 0) {
+            lockdownTime = lockdownTime * 2;
+        } else {
+            lockdownTime = baseLockdownTime;
+        }
+
+        lockdownTime = Math.min(maxLockdownTime, lockdownTime);
+        lockdownStartTime = clock.date();
+    }
+
+    public synchronized void setBaseLockdownTime(long baseLockdownTime) {
+        this.baseLockdownTime = baseLockdownTime;
+    }
+
+    public synchronized void setMaxLockdownTime(long maxLockdownTime) {
+        this.maxLockdownTime = maxLockdownTime;
+    }
+}

--- a/raven/src/main/java/com/getsentry/raven/connection/LockdownManager.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/LockdownManager.java
@@ -70,7 +70,7 @@ public class LockdownManager {
     /**
      * Reset the lockdown state, disabling lockdown and setting the backoff time to zero.
      */
-    public synchronized void resetLockdown() {
+    public synchronized void resetState() {
         lockdownTime = 0;
         lockdownStartTime = null;
     }
@@ -82,7 +82,7 @@ public class LockdownManager {
      * @param connectionException ConnectionException to check for a recommended
      *                            lockdown time, may be null
      */
-    public synchronized void setLockdownState(ConnectionException connectionException) {
+    public synchronized void setState(ConnectionException connectionException) {
         // If we are already in a lockdown state, don't change anything
         if (isLockedDown()) {
             return;

--- a/raven/src/main/java/com/getsentry/raven/connection/LockedDownException.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/LockedDownException.java
@@ -1,0 +1,17 @@
+package com.getsentry.raven.connection;
+
+/**
+ * Exception thrown when attempting to send Events while in a lockdown.
+ */
+public class LockedDownException extends RuntimeException {
+
+    /**
+     * Construct a LockedDownException with a message.
+     *
+     * @param message Exception message.
+     */
+    public LockedDownException(String message) {
+        super(message);
+    }
+
+}

--- a/raven/src/main/java/com/getsentry/raven/dsn/Dsn.java
+++ b/raven/src/main/java/com/getsentry/raven/dsn/Dsn.java
@@ -244,9 +244,9 @@ public class Dsn {
     }
 
     /**
-     * Creates the URI of the sentry server.
+     * Creates the URI of the Sentry server.
      *
-     * @return the URI of the sentry server.
+     * @return the URI of the Sentry server.
      */
     public URI getUri() {
         return uri;

--- a/raven/src/main/java/com/getsentry/raven/time/Clock.java
+++ b/raven/src/main/java/com/getsentry/raven/time/Clock.java
@@ -5,7 +5,7 @@ import java.util.Date;
 /**
  * Clock interface, used to inject a Clock dependency so time can be adjusted in tests.
  */
-interface Clock {
+public interface Clock {
 
     /**
      * Returns the Clock's time in milliseconds.

--- a/raven/src/test/java/com/getsentry/raven/connection/AbstractConnectionTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/AbstractConnectionTest.java
@@ -1,15 +1,15 @@
 package com.getsentry.raven.connection;
 
+import com.getsentry.raven.time.Clock;
+import com.getsentry.raven.time.FixedClock;
 import mockit.*;
 import com.getsentry.raven.event.Event;
 import org.testng.annotations.Test;
 
-import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
-import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
 
 import static mockit.Deencapsulation.getField;
 import static mockit.Deencapsulation.setField;
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class AbstractConnectionTest {
+    private static final Date FIXED_DATE = new Date(1483228800L);
     @Injectable
     private final String publicKey = "9bcf4a8c-f353-4f25-9dda-76a873fff905";
     @Injectable
@@ -24,12 +25,7 @@ public class AbstractConnectionTest {
     @Tested
     private AbstractConnection abstractConnection = null;
     @Injectable
-    private Lock mockLock = null;
-    @Injectable
-    private Condition mockCondition = null;
-    //Disable thread sleep during the tests
-    @Mocked("sleep")
-    private Thread mockThread = null;
+    private final Clock mockClock = new FixedClock(FIXED_DATE);
 
     @Test
     public void testAuthHeader() throws Exception {
@@ -43,9 +39,6 @@ public class AbstractConnectionTest {
 
     @Test
     public void testSuccessfulSendCallsDoSend(@Injectable final Event mockEvent) throws Exception {
-        setField(abstractConnection, "lock", mockLock);
-        setField(abstractConnection, "condition", mockCondition);
-
         abstractConnection.send(mockEvent);
 
         new Verifications() {{
@@ -55,8 +48,8 @@ public class AbstractConnectionTest {
 
     @Test
     public void testExceptionOnSendStartLockDown(@Injectable final Event mockEvent) throws Exception {
-        setField(abstractConnection, "lock", mockLock);
-        setField(abstractConnection, "condition", mockCondition);
+        setField(abstractConnection, "clock", mockClock);
+
         new NonStrictExpectations() {{
             abstractConnection.doSend((Event) any);
             result = new ConnectionException();
@@ -68,15 +61,14 @@ public class AbstractConnectionTest {
             // ignore
         }
 
-        new Verifications() {{
-            mockLock.lock();
-            mockCondition.signalAll();
-            mockLock.unlock();
-        }};
+        Date lockdownStartTime = getField(abstractConnection, "lockdownStartTime");
+        assertThat(lockdownStartTime, is(FIXED_DATE));
     }
 
     @Test
     public void testLockDownDoublesTheWaitingTime(@Injectable final Event mockEvent) throws Exception {
+        setField(abstractConnection, "clock", mockClock);
+
         new NonStrictExpectations() {{
             abstractConnection.doSend((Event) any);
             result = new ConnectionException();
@@ -88,16 +80,31 @@ public class AbstractConnectionTest {
             // ignore
         }
 
-        long waitingTimeAfter = getField(abstractConnection, "waitingTime");
-        assertThat(waitingTimeAfter, is(AbstractConnection.DEFAULT_BASE_WAITING_TIME * 2));
-        new Verifications() {{
-            Thread.sleep(AbstractConnection.DEFAULT_BASE_WAITING_TIME);
-        }};
+        // Check for default lockdown time
+        long lockdownWaitingTimeAfter = getField(abstractConnection, "lockdownWaitingTime");
+        assertThat(lockdownWaitingTimeAfter, is(AbstractConnection.DEFAULT_BASE_WAITING_TIME));
+
+        // Roll forward 10ms, allowing the lockdown to retried
+        ((FixedClock) mockClock).tick(10, TimeUnit.MILLISECONDS);
+
+        // Send a second event, doubling the lockdown
+        try {
+            abstractConnection.send(mockEvent);
+        } catch (Exception e) {
+            // ignore
+        }
+
+        // Check for doubled lockdown time
+        long lockdownWaitingTimeAfter2 = getField(abstractConnection, "lockdownWaitingTime");
+        assertThat(lockdownWaitingTimeAfter2, is(AbstractConnection.DEFAULT_BASE_WAITING_TIME * 2));
     }
 
     @Test
     public void testLockDownDoesntDoubleItAtMax(@Injectable final Event mockEvent) throws Exception {
-        setField(abstractConnection, "waitingTime", AbstractConnection.DEFAULT_MAX_WAITING_TIME);
+        setField(abstractConnection, "lockdownWaitingTime", AbstractConnection.DEFAULT_MAX_WAITING_TIME);
+        setField(abstractConnection, "lockdownStartTime", mockClock.date());
+        setField(abstractConnection, "clock", mockClock);
+
         new NonStrictExpectations() {{
             abstractConnection.doSend((Event) any);
             result = new ConnectionException();
@@ -109,11 +116,8 @@ public class AbstractConnectionTest {
             // ignore
         }
 
-        long waitingTimeAfter = getField(abstractConnection, "waitingTime");
-        assertThat(waitingTimeAfter, is(AbstractConnection.DEFAULT_MAX_WAITING_TIME));
-        new Verifications() {{
-            Thread.sleep(AbstractConnection.DEFAULT_MAX_WAITING_TIME);
-        }};
+        long lockdownWaitingTimeAfter = getField(abstractConnection, "lockdownWaitingTime");
+        assertThat(lockdownWaitingTimeAfter, is(AbstractConnection.DEFAULT_MAX_WAITING_TIME));
     }
 
     @Test
@@ -142,8 +146,26 @@ public class AbstractConnectionTest {
             // ignore
         }
 
-
         assertThat(callbackCalled.get(), is(true));
     }
 
+    @Test
+    public void testRecommendedLockdownRespected(@Injectable final Event mockEvent) throws Exception {
+        setField(abstractConnection, "clock", mockClock);
+
+        final long recommendedLockdownWaitTime = 12345L;
+        new NonStrictExpectations() {{
+            abstractConnection.doSend((Event) any);
+            result = new ConnectionException("Message", null, recommendedLockdownWaitTime);
+        }};
+
+        try {
+            abstractConnection.send(mockEvent);
+        } catch (Exception e) {
+            // ignore
+        }
+
+        long lockdownWaitingTimeAfter = getField(abstractConnection, "lockdownWaitingTime");
+        assertThat(lockdownWaitingTimeAfter, is(recommendedLockdownWaitTime));
+    }
 }

--- a/raven/src/test/java/com/getsentry/raven/connection/AbstractConnectionTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/AbstractConnectionTest.java
@@ -1,6 +1,5 @@
 package com.getsentry.raven.connection;
 
-import com.getsentry.raven.time.Clock;
 import com.getsentry.raven.time.FixedClock;
 import mockit.*;
 import com.getsentry.raven.event.Event;
@@ -26,13 +25,13 @@ public class AbstractConnectionTest {
     private final String secretKey = "56a9d05e-9032-4fdd-8f67-867d526422f9";
     @Tested
     private AbstractConnection abstractConnection = null;
-    private FixedClock clock = new FixedClock(FIXED_DATE);
-    private LockdownManager lockdownManager = new LockdownManager(clock);
+    private FixedClock fixedClock = new FixedClock(FIXED_DATE);
+    private LockdownManager lockdownManager = new LockdownManager(fixedClock);
 
     @BeforeMethod
     public void setup() {
-        clock = new FixedClock(FIXED_DATE);
-        lockdownManager = new LockdownManager(clock);
+        fixedClock = new FixedClock(FIXED_DATE);
+        lockdownManager = new LockdownManager(fixedClock);
     }
 
     @Test
@@ -101,7 +100,7 @@ public class AbstractConnectionTest {
         assertThat(lockdownTimeAfter, is(LockdownManager.DEFAULT_BASE_LOCKDOWN_TIME));
 
         // Roll forward by the base lockdown time, allowing the lockdown to retried
-        clock.tick(LockdownManager.DEFAULT_BASE_LOCKDOWN_TIME, TimeUnit.MILLISECONDS);
+        fixedClock.tick(LockdownManager.DEFAULT_BASE_LOCKDOWN_TIME, TimeUnit.MILLISECONDS);
 
         // Send a second event, doubling the lockdown
         try {
@@ -119,7 +118,7 @@ public class AbstractConnectionTest {
     public void testLockDownDoesntDoubleItAtMax(@Injectable final Event mockEvent) throws Exception {
         setField(abstractConnection, "lockdownManager", lockdownManager);
         setField(lockdownManager, "lockdownTime", LockdownManager.DEFAULT_MAX_LOCKDOWN_TIME);
-        setField(lockdownManager, "lockdownStartTime", clock.date());
+        setField(lockdownManager, "lockdownStartTime", fixedClock.date());
 
         new NonStrictExpectations() {{
             abstractConnection.doSend((Event) any);

--- a/raven/src/test/java/com/getsentry/raven/connection/BufferedConnectionTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/BufferedConnectionTest.java
@@ -4,9 +4,7 @@ import com.getsentry.raven.BaseTest;
 import com.getsentry.raven.buffer.Buffer;
 import com.getsentry.raven.event.Event;
 import com.getsentry.raven.event.EventBuilder;
-import com.getsentry.raven.time.Clock;
 import com.getsentry.raven.time.FixedClock;
-import mockit.Injectable;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -28,8 +26,8 @@ import static org.hamcrest.core.Is.is;
 
 public class BufferedConnectionTest extends BaseTest {
     private static final Date FIXED_DATE = new Date(1483228800L);
-    private FixedClock clock = new FixedClock(FIXED_DATE);
-    private LockdownManager lockdownManager = new LockdownManager(clock);
+    private FixedClock fixedClock = new FixedClock(FIXED_DATE);
+    private LockdownManager lockdownManager = new LockdownManager(fixedClock);
 
     private Set<Event> bufferedEvents;
     private List<Event> sentEvents;
@@ -65,8 +63,8 @@ public class BufferedConnectionTest extends BaseTest {
             }
         };
 
-        clock = new FixedClock(FIXED_DATE);
-        lockdownManager = new LockdownManager(clock);
+        fixedClock = new FixedClock(FIXED_DATE);
+        lockdownManager = new LockdownManager(fixedClock);
 
         mockBuffer = new Buffer() {
             @Override
@@ -120,7 +118,7 @@ public class BufferedConnectionTest extends BaseTest {
         assertThat(bufferedEvents.size(), equalTo(2));
 
         // End the lockdown
-        clock.tick(LockdownManager.DEFAULT_MAX_LOCKDOWN_TIME, TimeUnit.MILLISECONDS);
+        fixedClock.tick(LockdownManager.DEFAULT_MAX_LOCKDOWN_TIME, TimeUnit.MILLISECONDS);
 
         connectionUp = true;
         waitUntilTrue(1000, new Callable<Boolean>() {

--- a/raven/src/test/java/com/getsentry/raven/connection/BufferedConnectionTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/BufferedConnectionTest.java
@@ -4,6 +4,9 @@ import com.getsentry.raven.BaseTest;
 import com.getsentry.raven.buffer.Buffer;
 import com.getsentry.raven.event.Event;
 import com.getsentry.raven.event.EventBuilder;
+import com.getsentry.raven.time.Clock;
+import com.getsentry.raven.time.FixedClock;
+import mockit.Injectable;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -11,15 +14,23 @@ import org.testng.collections.Lists;
 import org.testng.collections.Sets;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
+import static mockit.Deencapsulation.setField;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
 
 public class BufferedConnectionTest extends BaseTest {
+    private static final Date FIXED_DATE = new Date(1483228800L);
+    @Injectable
+    private final Clock mockClock = new FixedClock(FIXED_DATE);
+
     private Set<Event> bufferedEvents;
     private List<Event> sentEvents;
     private Buffer mockBuffer;
@@ -33,9 +44,9 @@ public class BufferedConnectionTest extends BaseTest {
         sentEvents = Lists.newArrayList();
         connectionUp = true;
 
-        mockConnection = new Connection() {
+        mockConnection = new AbstractConnection("public", "private") {
             @Override
-            public void send(Event event) throws ConnectionException {
+            protected void doSend(Event event) throws ConnectionException {
                 if (connectionUp) {
                     sentEvents.add(event);
                 } else {
@@ -53,6 +64,8 @@ public class BufferedConnectionTest extends BaseTest {
 
             }
         };
+
+        setField(mockConnection, "clock", mockClock);
 
         mockBuffer = new Buffer() {
             @Override
@@ -94,6 +107,18 @@ public class BufferedConnectionTest extends BaseTest {
         assertThat(bufferedEvents.size(), equalTo(1));
         assertThat(bufferedEvents.iterator().next(), equalTo(event));
 
+        // Attempt sending a second event (should be in lockdown)
+        Event event2 = new EventBuilder().build();
+        try {
+            bufferedConnection.send(event2);
+        } catch (Exception e) {
+
+        }
+        assertThat(bufferedEvents.size(), equalTo(2));
+
+        // End the lockdown
+        ((FixedClock) mockClock).tick(AbstractConnection.DEFAULT_MAX_LOCKDOWN_TIME, TimeUnit.MILLISECONDS);
+
         connectionUp = true;
         waitUntilTrue(1000, new Callable<Boolean>() {
             @Override
@@ -102,6 +127,7 @@ public class BufferedConnectionTest extends BaseTest {
             }
         });
         assertThat(bufferedEvents.size(), equalTo(0));
-        assertThat(sentEvents.get(0), equalTo(event));
+        assertThat(sentEvents.contains(event), is(true));
+        assertThat(sentEvents.contains(event2), is(true));
     }
 }

--- a/raven/src/test/java/com/getsentry/raven/connection/HttpConnectionTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/HttpConnectionTest.java
@@ -153,7 +153,7 @@ public class HttpConnectionTest {
             httpConnection.doSend(mockEvent);
             fail();
         } catch (ConnectionException e) {
-            assertThat(e.getRecommendedLockdownWaitTime(), is(12345L * 1000L));
+            assertThat(e.getRecommendedLockdownTime(), is(12345L * 1000L));
         }
     }
 

--- a/raven/src/test/java/com/getsentry/raven/connection/HttpConnectionTest.java
+++ b/raven/src/test/java/com/getsentry/raven/connection/HttpConnectionTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
+import static org.testng.Assert.fail;
 
 public class HttpConnectionTest {
     @Injectable
@@ -134,6 +135,26 @@ public class HttpConnectionTest {
         }};
 
         httpConnection.doSend(mockEvent);
+    }
+
+    @Test
+    public void testRetryAfterHeader(@Injectable final Event mockEvent) throws Exception {
+        final String httpErrorMessage = "93e3ddb1-c4f3-46c3-9900-529de83678b7";
+        new NonStrictExpectations() {{
+            mockUrlConnection.getOutputStream();
+            result = new IOException();
+            mockUrlConnection.getErrorStream();
+            result = new ByteArrayInputStream(httpErrorMessage.getBytes());
+            mockUrlConnection.getHeaderField("Retry-After");
+            result = "12345";
+        }};
+
+        try {
+            httpConnection.doSend(mockEvent);
+            fail();
+        } catch (ConnectionException e) {
+            assertThat(e.getRecommendedLockdownWaitTime(), is(12345L * 1000L));
+        }
     }
 
     @Test


### PR DESCRIPTION
…es, add support for Retry-After header.

Note: This is modeled off the backoff code in [raven-js](https://github.com/getsentry/raven-js/blob/master/src/raven.js) (search `backoff` if curious, it's spread around)

* No longer block threads when in a lockdown, instead drop events like our other SDKs do.
* This means we needed to drop the `Lock` and `Condition` code (which is all about blocking) and I switched to tracking the current wait time and the starting time of the wait, like JS.
* This also means I had to add some `synchronized` because we're dealing with two different variables that can change. None of the methods do I/O.
* Changed to default base lockdown time of 1 second, to match JS, 10ms seemed like a tiny start anyway.
* Allow subclasses to assign a `recommendedLockdownTime` when they throw an `ConnectionException`. This is to allow for `HttpConnection` passing up information from the `Retry-After` header (and may have use in other `Connection`s?). Open to other options but this seemed the cleanest.
* Buffering still works -- in a lockdown those events will (as of #305) be written to disk before, and a `LockedDownException` will immediately be thrown. They will be retried later as usual.
* `BufferedConnectionTest` changes are there to verify the lockdown logic works.