### PR TITLE
	Add lockdownLogger so that lockdown messages can be squelched.

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -1,6 +1,7 @@
 package com.getsentry.raven;
 
 import com.getsentry.raven.connection.Connection;
+import com.getsentry.raven.connection.LockedDownException;
 import com.getsentry.raven.environment.RavenEnvironment;
 import com.getsentry.raven.event.Event;
 import com.getsentry.raven.event.EventBuilder;
@@ -23,6 +24,9 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class Raven {
     private static final Logger logger = LoggerFactory.getLogger(Raven.class);
+    // CHECKSTYLE.OFF: ConstantName
+    private static final Logger lockdownLogger = LoggerFactory.getLogger(Raven.class + ".lockdown");
+    // CHECKSTYLE.ON: ConstantName
     /**
      * The most recently constructed Raven instance, used by static helper methods like {@link Raven#capture(Event)}.
      */
@@ -93,6 +97,8 @@ public class Raven {
     public void sendEvent(Event event) {
         try {
             connection.send(event);
+        } catch (LockedDownException e) {
+            lockdownLogger.warn("The connection to Sentry is currently locked down.", e);
         } catch (Exception e) {
             logger.error("An exception occurred while sending the event to Sentry.", e);
         } finally {


### PR DESCRIPTION
This builds on #319, so ignore until that lands (or just check the last commit).

This should help with #291 and #312, because lockdown exceptions will go to their own, easy to disable, logger. (It's *much* easier and more common to disable a logger than it is to drop certain exception classes -- I'm not even sure if all logging frameworks allow the latter.) I also changed the level from `error` to `warn` (to match `raven-js`). But `raven-js` doesn't tie into a bunch of existing application loggers ... I'm tempted for this to be `INFO` or `DEBUG`, because we already log when the lockdown is initiated.

It ends up looking like this (example from `jul`):

```java
// Called when in lockdown
logger.log(Level.SEVERE, "This is a test");
```

```
[RAVEN] [WARN ] class com.getsentry.raven.Raven.lockdown - The connection to Sentry is currently locked down.
[RAVEN] [ERROR] log4j.SentryAppenderIT - This is a test
```