### PR TITLE
Only 'store' events in integration tests if the response is a 200.

### DIFF
--- a/raven/src/test/java/com/getsentry/raven/BaseIT.java
+++ b/raven/src/test/java/com/getsentry/raven/BaseIT.java
@@ -63,9 +63,11 @@ public class BaseIT extends BaseTest {
         List<UnmarshalledEvent> events = new ArrayList<>();
 
         for (ServeEvent serveEvent : wireMockRule.getAllServeEvents()) {
-            UnmarshalledEvent event = unmarshaller.unmarshal(new ByteArrayInputStream(serveEvent.getRequest().getBody()));
-            if (event != null) {
-                events.add(event);
+            if (serveEvent.getResponse().getStatus() == 200) {
+                UnmarshalledEvent event = unmarshaller.unmarshal(new ByteArrayInputStream(serveEvent.getRequest().getBody()));
+                if (event != null) {
+                    events.add(event);
+                }
             }
         }
 


### PR DESCRIPTION
Minor fix.

I was getting lucky because so far I'm only testing 200 responses, but I noticed this while working on something else.