### PR TITLE
Add optional 'body' field to HttpInterface.

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/event/interfaces/HttpInterface.java
+++ b/raven/src/main/java/com/getsentry/raven/event/interfaces/HttpInterface.java
@@ -32,6 +32,7 @@ public class HttpInterface implements SentryInterface {
     private final String authType;
     private final String remoteUser;
     private final Map<String, Collection<String>> headers;
+    private final String body;
 
     /**
      * This constructor is for compatibility reasons and should not be used.
@@ -49,6 +50,17 @@ public class HttpInterface implements SentryInterface {
      * @param remoteAddressResolver RemoteAddressResolver
      */
     public HttpInterface(HttpServletRequest request, RemoteAddressResolver remoteAddressResolver) {
+        this(request, remoteAddressResolver, null);
+    }
+
+    /**
+     * Creates a an HTTP element for an {@link com.getsentry.raven.event.Event}.
+     *
+     * @param request Captured HTTP request to send to Sentry.
+     * @param remoteAddressResolver RemoteAddressResolver
+     * @param body HTTP request body (optional)
+     */
+    public HttpInterface(HttpServletRequest request, RemoteAddressResolver remoteAddressResolver, String body) {
         this.requestUrl = request.getRequestURL().toString();
         this.method = request.getMethod();
         this.parameters = new HashMap<>();
@@ -79,6 +91,7 @@ public class HttpInterface implements SentryInterface {
         for (String headerName : Collections.list(request.getHeaderNames())) {
             this.headers.put(headerName, Collections.list(request.getHeaders(headerName)));
         }
+        this.body = body;
     }
 
     @Override
@@ -148,6 +161,10 @@ public class HttpInterface implements SentryInterface {
 
     public String getRemoteUser() {
         return remoteUser;
+    }
+
+    public String getBody() {
+        return body;
     }
 
     public Map<String, Collection<String>> getHeaders() {
@@ -224,6 +241,9 @@ public class HttpInterface implements SentryInterface {
             return false;
         }
         if (serverName != null ? !serverName.equals(that.serverName) : that.serverName != null) {
+            return false;
+        }
+        if (body != null ? !body.equals(that.body) : that.body != null) {
             return false;
         }
 

--- a/raven/src/main/java/com/getsentry/raven/event/interfaces/HttpInterface.java
+++ b/raven/src/main/java/com/getsentry/raven/event/interfaces/HttpInterface.java
@@ -44,7 +44,7 @@ public class HttpInterface implements SentryInterface {
     }
 
     /**
-     * Creates a an HTTP element for an {@link com.getsentry.raven.event.Event}.
+     * Creates an HTTP element for an {@link com.getsentry.raven.event.Event}.
      *
      * @param request Captured HTTP request to send to Sentry.
      * @param remoteAddressResolver RemoteAddressResolver
@@ -54,7 +54,7 @@ public class HttpInterface implements SentryInterface {
     }
 
     /**
-     * Creates a an HTTP element for an {@link com.getsentry.raven.event.Event}.
+     * Creates an HTTP element for an {@link com.getsentry.raven.event.Event}.
      *
      * @param request Captured HTTP request to send to Sentry.
      * @param remoteAddressResolver RemoteAddressResolver

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/HttpInterfaceBinding.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/HttpInterfaceBinding.java
@@ -14,8 +14,12 @@ import java.util.Map;
 public class HttpInterfaceBinding implements InterfaceBinding<HttpInterface> {
     /**
      * Maximum length for the HTTP request body.
+     *
+     * See <a href="https://docs.sentry.io/clientdev/data-handling/#variable-size">the SDK reference</a>
+     * for more information.
      */
-    public static final int MAX_BODY_LENGTH = 1000;
+    public static final int MAX_BODY_LENGTH = 2048;
+
     private static final String URL = "url";
     private static final String METHOD = "method";
     private static final String DATA = "data";

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -8,6 +8,7 @@ import com.getsentry.raven.util.Base64OutputStream;
 import com.getsentry.raven.event.Event;
 import com.getsentry.raven.event.interfaces.SentryInterface;
 import com.getsentry.raven.marshaller.Marshaller;
+import com.getsentry.raven.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,7 +168,7 @@ public class JsonMarshaller implements Marshaller {
         generator.writeStartObject();
 
         generator.writeStringField(EVENT_ID, formatId(event.getId()));
-        generator.writeStringField(MESSAGE, trimMessage(event.getMessage()));
+        generator.writeStringField(MESSAGE, Util.trimString(event.getMessage(), maxMessageLength));
         generator.writeStringField(TIMESTAMP, ISO_FORMAT.get().format(event.getTimestamp()));
         generator.writeStringField(LEVEL, formatLevel(event.getLevel()));
         generator.writeStringField(LOGGER, event.getLogger());
@@ -331,22 +332,6 @@ public class JsonMarshaller implements Marshaller {
             generator.writeEndObject();
         }
         generator.writeEndObject();
-    }
-
-    /**
-     * Trims a message, ensuring that the maximum length {@link #maxMessageLength} isn't reached.
-     *
-     * @param message message to format.
-     * @return trimmed message (shortened if necessary).
-     */
-    private String trimMessage(String message) {
-        if (message == null) {
-            return null;
-        } else if (message.length() > maxMessageLength) {
-            return message.substring(0, maxMessageLength);
-        } else {
-            return message;
-        }
     }
 
     /**

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/MessageInterfaceBinding.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/MessageInterfaceBinding.java
@@ -2,6 +2,7 @@ package com.getsentry.raven.marshaller.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.getsentry.raven.event.interfaces.MessageInterface;
+import com.getsentry.raven.util.Util;
 
 import java.io.IOException;
 
@@ -38,33 +39,18 @@ public class MessageInterfaceBinding implements InterfaceBinding<MessageInterfac
         this.maxMessageLength = maxMessageLength;
     }
 
-    /**
-     * Trims a message, ensuring that the maximum length {@link #maxMessageLength} isn't reached.
-     *
-     * @param message message to format.
-     * @return trimmed message (shortened if necessary).
-     */
-    private String trimMessage(String message) {
-        if (message == null) {
-            return null;
-        } else if (message.length() > maxMessageLength) {
-            return message.substring(0, maxMessageLength);
-        } else {
-            return message;
-        }
-    }
-
     @Override
     public void writeInterface(JsonGenerator generator, MessageInterface messageInterface) throws IOException {
         generator.writeStartObject();
-        generator.writeStringField(MESSAGE_PARAMETER, trimMessage(messageInterface.getMessage()));
+        generator.writeStringField(MESSAGE_PARAMETER, Util.trimString(messageInterface.getMessage(), maxMessageLength));
         generator.writeArrayFieldStart(PARAMS_PARAMETER);
         for (String parameter : messageInterface.getParameters()) {
             generator.writeString(parameter);
         }
         generator.writeEndArray();
         if (messageInterface.getFormatted() != null) {
-            generator.writeStringField(FORMATTED_PARAMETER, trimMessage(messageInterface.getFormatted()));
+            generator.writeStringField(FORMATTED_PARAMETER,
+                Util.trimString(messageInterface.getFormatted(), maxMessageLength));
         }
         generator.writeEndObject();
     }

--- a/raven/src/main/java/com/getsentry/raven/util/Util.java
+++ b/raven/src/main/java/com/getsentry/raven/util/Util.java
@@ -121,7 +121,7 @@ public final class Util {
         if (string == null) {
             return null;
         } else if (string.length() > maxMessageLength) {
-            return string.substring(0, maxMessageLength);
+            return string.substring(0, maxMessageLength - 3) + "...";
         } else {
             return string;
         }

--- a/raven/src/main/java/com/getsentry/raven/util/Util.java
+++ b/raven/src/main/java/com/getsentry/raven/util/Util.java
@@ -109,4 +109,22 @@ public final class Util {
         }
         return Double.parseDouble(value);
     }
+
+    /**
+     * Trims a String, ensuring that the maximum length isn't reached.
+     *
+     * @param string string to trim
+     * @param maxMessageLength maximum length of the string
+     * @return trimmed string
+     */
+    public static String trimString(String string, int maxMessageLength) {
+        if (string == null) {
+            return null;
+        } else if (string.length() > maxMessageLength) {
+            return string.substring(0, maxMessageLength);
+        } else {
+            return string;
+        }
+    }
+
 }

--- a/raven/src/main/java/com/getsentry/raven/util/Util.java
+++ b/raven/src/main/java/com/getsentry/raven/util/Util.java
@@ -121,7 +121,9 @@ public final class Util {
         if (string == null) {
             return null;
         } else if (string.length() > maxMessageLength) {
+            // CHECKSTYLE.OFF: MagicNumber
             return string.substring(0, maxMessageLength - 3) + "...";
+            // CHECKSTYLE.ON: MagicNumber
         } else {
             return string;
         }

--- a/raven/src/test/java/com/getsentry/raven/marshaller/json/HttpInterfaceBindingTest.java
+++ b/raven/src/test/java/com/getsentry/raven/marshaller/json/HttpInterfaceBindingTest.java
@@ -55,6 +55,8 @@ public class HttpInterfaceBindingTest {
             result = "5.6.7.8";
             mockMessageInterface.getLocalName();
             result = "local-name";
+            mockMessageInterface.getBody();
+            result = "body";
         }};
 
         interfaceBinding.writeInterface(jsonGeneratorParser.generator(), mockMessageInterface);

--- a/raven/src/test/resources/com/getsentry/raven/marshaller/json/Http1.json
+++ b/raven/src/test/resources/com/getsentry/raven/marshaller/json/Http1.json
@@ -1,7 +1,9 @@
 {
   "url": "http://host/url",
   "method": "GET",
-  "data": {},
+  "data": {
+    "body": "body"
+  },
   "query_string": "query",
   "cookies": {
     "Cookie1": "Value1"


### PR DESCRIPTION
This is step 1 of #273, which just allows people to provide the `body` manually if they attach their own `HttpInterface` instance.

Not sure what size to trim the body to, or if we should allow overrides of that size?