### PR TITLE
Use Raven.class.getName for lockdown logger

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class Raven {
     private static final Logger logger = LoggerFactory.getLogger(Raven.class);
     // CHECKSTYLE.OFF: ConstantName
-    private static final Logger lockdownLogger = LoggerFactory.getLogger(Raven.class + ".lockdown");
+    private static final Logger lockdownLogger = LoggerFactory.getLogger(Raven.class.getName() + ".lockdown");
     // CHECKSTYLE.ON: ConstantName
     /**
      * The most recently constructed Raven instance, used by static helper methods like {@link Raven#capture(Event)}.

--- a/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AsyncConnection.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 public class AsyncConnection implements Connection {
     private static final Logger logger = LoggerFactory.getLogger(AsyncConnection.class);
     // CHECKSTYLE.OFF: ConstantName
-    private static final Logger lockdownLogger = LoggerFactory.getLogger(Raven.class + ".lockdown");
+    private static final Logger lockdownLogger = LoggerFactory.getLogger(Raven.class.getName() + ".lockdown");
     // CHECKSTYLE.ON: ConstantName
     /**
      * Timeout of the {@link #executorService}, in milliseconds.


### PR DESCRIPTION
A minor QOL commit, but I assume that the intention was to use the class name for lockdown loggers? Right now the lockdown logger is called `class com.getsentry.raven.Raven.lockdown`, which has an unnecessary `class` in the logger name. Should have caught this in my earlier commit.