### PR TITLE
Remove uses of slf4j from the core raven library.

### DIFF
--- a/raven/pom.xml
+++ b/raven/pom.xml
@@ -20,10 +20,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <scope>provided</scope>

--- a/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
+++ b/raven/src/main/java/com/getsentry/raven/DefaultRavenFactory.java
@@ -10,8 +10,6 @@ import com.getsentry.raven.event.interfaces.*;
 import com.getsentry.raven.marshaller.Marshaller;
 import com.getsentry.raven.marshaller.json.*;
 import com.getsentry.raven.util.Util;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.InetSocketAddress;
@@ -24,6 +22,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Default implementation of {@link RavenFactory}.
@@ -177,7 +177,7 @@ public class DefaultRavenFactory extends RavenFactory {
      */
     public static final int HTTP_PROXY_PORT_DEFAULT = 80;
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultRavenFactory.class);
+    private static final Logger logger = Logger.getLogger(DefaultRavenFactory.class.getName());
     private static final String FALSE = Boolean.FALSE.toString();
 
     private static final Map<String, RejectedExecutionHandler> REJECT_EXECUTION_HANDLERS = new HashMap<>();
@@ -197,7 +197,7 @@ public class DefaultRavenFactory extends RavenFactory {
             Class.forName("javax.servlet.ServletRequestListener", false, this.getClass().getClassLoader());
             raven.addBuilderHelper(new HttpEventBuilderHelper());
         } catch (ClassNotFoundException e) {
-            logger.debug("The current environment doesn't provide access to servlets,"
+            logger.log(Level.FINE, "The current environment doesn't provide access to servlets,"
                 + "or provides an unsupported version.");
         }
         raven.addBuilderHelper(new ContextBuilderHelper(raven));

--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -7,13 +7,13 @@ import com.getsentry.raven.event.Event;
 import com.getsentry.raven.event.EventBuilder;
 import com.getsentry.raven.event.helper.EventBuilderHelper;
 import com.getsentry.raven.event.interfaces.ExceptionInterface;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Raven is a client for Sentry allowing to send an {@link Event} that will be processed and sent to a Sentry server.
@@ -23,9 +23,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * create a sensible instance of Raven.
  */
 public class Raven {
-    private static final Logger logger = LoggerFactory.getLogger(Raven.class);
+    private static final Logger logger = Logger.getLogger(Raven.class.getName());
     // CHECKSTYLE.OFF: ConstantName
-    private static final Logger lockdownLogger = LoggerFactory.getLogger(Raven.class.getName() + ".lockdown");
+    private static final Logger lockdownLogger = Logger.getLogger(Raven.class.getName() + ".lockdown");
     // CHECKSTYLE.ON: ConstantName
     /**
      * The most recently constructed Raven instance, used by static helper methods like {@link Raven#capture(Event)}.
@@ -98,9 +98,9 @@ public class Raven {
         try {
             connection.send(event);
         } catch (LockedDownException e) {
-            lockdownLogger.warn("The connection to Sentry is currently locked down.", e);
+            lockdownLogger.log(Level.WARNING, "The connection to Sentry is currently locked down.", e);
         } catch (Exception e) {
-            logger.error("An exception occurred while sending the event to Sentry.", e);
+            logger.log(Level.SEVERE, "An exception occurred while sending the event to Sentry.", e);
         } finally {
             getContext().setLastEventId(event.getId());
         }
@@ -154,7 +154,7 @@ public class Raven {
      * @param builderHelper builder helper to remove.
      */
     public void removeBuilderHelper(EventBuilderHelper builderHelper) {
-        logger.debug("Removing '{}' from the list of builder helpers.", builderHelper);
+        logger.log(Level.FINE, "Removing '" + builderHelper + "' from the list of builder helpers.");
         builderHelpers.remove(builderHelper);
     }
 
@@ -164,7 +164,7 @@ public class Raven {
      * @param builderHelper builder helper to add.
      */
     public void addBuilderHelper(EventBuilderHelper builderHelper) {
-        logger.debug("Adding '{}' to the list of builder helpers.", builderHelper);
+        logger.log(Level.FINE, "Adding '" + builderHelper + "' to the list of builder helpers.");
         builderHelpers.add(builderHelper);
     }
 

--- a/raven/src/main/java/com/getsentry/raven/config/JndiLookup.java
+++ b/raven/src/main/java/com/getsentry/raven/config/JndiLookup.java
@@ -1,12 +1,11 @@
 package com.getsentry.raven.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.naming.NoInitialContextException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Handles JNDI lookup of a provided key within the Sentry namespace.
@@ -16,7 +15,7 @@ public final class JndiLookup {
      * Lookup prefix for Sentry configuration in JNDI.
      */
     private static final String JNDI_PREFIX = "java:comp/env/sentry/";
-    private static final Logger logger = LoggerFactory.getLogger(JndiLookup.class);
+    private static final Logger logger = Logger.getLogger(JndiLookup.class.getName());
 
     private JndiLookup() {
 
@@ -34,11 +33,11 @@ public final class JndiLookup {
             Context c = new InitialContext();
             value = (String) c.lookup(JNDI_PREFIX + key);
         } catch (NoInitialContextException e) {
-            logger.debug("JNDI not configured for Sentry (NoInitialContextEx)");
+            logger.log(Level.FINE, "JNDI not configured for Sentry (NoInitialContextEx)");
         } catch (NamingException e) {
-            logger.debug("No /sentry/" + key + " in JNDI");
+            logger.log(Level.FINE, "No /sentry/" + key + " in JNDI");
         } catch (RuntimeException e) {
-            logger.warn("Odd RuntimeException while testing for JNDI", e);
+            logger.log(Level.WARNING, "Odd RuntimeException while testing for JNDI", e);
         }
         return value;
     }

--- a/raven/src/main/java/com/getsentry/raven/config/Lookup.java
+++ b/raven/src/main/java/com/getsentry/raven/config/Lookup.java
@@ -1,14 +1,15 @@
 package com.getsentry.raven.config;
 
 import com.getsentry.raven.dsn.Dsn;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Handle lookup of configuration keys by trying JNDI, System Environment, and Java System Properties.
  */
 public final class Lookup {
-    private static final Logger logger = LoggerFactory.getLogger(JndiLookup.class);
+    private static final Logger logger = Logger.getLogger(JndiLookup.class.getName());
 
     private Lookup() {
 
@@ -29,7 +30,7 @@ public final class Lookup {
             Class.forName("javax.naming.InitialContext", false, Dsn.class.getClassLoader());
             value = JndiLookup.jndiLookup(key);
         } catch (ClassNotFoundException | NoClassDefFoundError e) {
-            logger.debug("JNDI not available", e);
+            logger.log(Level.FINE, "JNDI not available", e);
         }
 
         // Try to obtain from a Java System Property

--- a/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/AbstractConnection.java
@@ -2,11 +2,11 @@ package com.getsentry.raven.connection;
 
 import com.getsentry.raven.environment.RavenEnvironment;
 import com.getsentry.raven.event.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Abstract connection to a Sentry server.
@@ -20,7 +20,7 @@ public abstract class AbstractConnection implements Connection {
      * Current Sentry protocol version.
      */
     public static final String SENTRY_PROTOCOL_VERSION = "6";
-    private static final Logger logger = LoggerFactory.getLogger(AbstractConnection.class);
+    private static final Logger logger = Logger.getLogger(AbstractConnection.class.getName());
     /**
      * Value of the X-Sentry-Auth header.
      */
@@ -76,12 +76,12 @@ public abstract class AbstractConnection implements Connection {
                 try {
                     eventSendFailureCallback.onFailure(event, e);
                 } catch (Exception exc) {
-                    logger.warn("An exception occurred while running an EventSendFailureCallback: "
+                    logger.log(Level.WARNING, "An exception occurred while running an EventSendFailureCallback: "
                         + eventSendFailureCallback.getClass().getName(), exc);
                 }
             }
 
-            logger.warn("An exception due to the connection occurred, a lockdown will be initiated.", e);
+            logger.log(Level.WARNING, "An exception due to the connection occurred, a lockdown will be initiated.", e);
             lockdownManager.setState(e);
 
             throw e;

--- a/raven/src/main/java/com/getsentry/raven/connection/HttpConnection.java
+++ b/raven/src/main/java/com/getsentry/raven/connection/HttpConnection.java
@@ -3,8 +3,6 @@ package com.getsentry.raven.connection;
 import com.getsentry.raven.environment.RavenEnvironment;
 import com.getsentry.raven.event.Event;
 import com.getsentry.raven.marshaller.Marshaller;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -17,6 +15,8 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Basic connection to a Sentry server, using HTTP and HTTPS.
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class HttpConnection extends AbstractConnection {
     private static final Charset UTF_8 = Charset.forName("UTF-8");
-    private static final Logger logger = LoggerFactory.getLogger(HttpConnection.class);
+    private static final Logger logger = Logger.getLogger(HttpConnection.class.getName());
     /**
      * HTTP Header for the user agent.
      */
@@ -204,7 +204,7 @@ public class HttpConnection extends AbstractConnection {
                 first = false;
             }
         } catch (Exception e2) {
-            logger.error("Exception while reading the error message from the connection.", e2);
+            logger.log(Level.SEVERE, "Exception while reading the error message from the connection.", e2);
         }
         return sb.toString();
     }

--- a/raven/src/main/java/com/getsentry/raven/dsn/Dsn.java
+++ b/raven/src/main/java/com/getsentry/raven/dsn/Dsn.java
@@ -1,14 +1,14 @@
 package com.getsentry.raven.dsn;
 
 import com.getsentry.raven.config.Lookup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Data Source name allowing a direct connection to a Sentry server.
@@ -18,7 +18,7 @@ public class Dsn {
      * Default DSN to use when auto detection fails.
      */
     public static final String DEFAULT_DSN = "noop://user:password@localhost:0/0";
-    private static final Logger logger = LoggerFactory.getLogger(Dsn.class);
+    private static final Logger logger = Logger.getLogger(Dsn.class.getName());
     private String secretKey;
     private String publicKey;
     private String projectId;
@@ -87,7 +87,7 @@ public class Dsn {
         String dsn = Lookup.lookup("dsn");
 
         if (dsn == null) {
-            logger.warn("Couldn't find a suitable DSN, defaulting to a Noop one.");
+            logger.log(Level.WARNING, "Couldn't find a suitable DSN, defaulting to a Noop one.");
             dsn = DEFAULT_DSN;
         }
 

--- a/raven/src/main/java/com/getsentry/raven/environment/RavenEnvironment.java
+++ b/raven/src/main/java/com/getsentry/raven/environment/RavenEnvironment.java
@@ -1,10 +1,9 @@
 package com.getsentry.raven.environment;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ResourceBundle;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Manages environment information on Raven.
@@ -30,7 +29,7 @@ public final class RavenEnvironment {
             return new AtomicInteger();
         }
     };
-    private static final Logger logger = LoggerFactory.getLogger(RavenEnvironment.class);
+    private static final Logger logger = Logger.getLogger(RavenEnvironment.class.getName());
 
     private RavenEnvironment() {
     }
@@ -53,7 +52,7 @@ public final class RavenEnvironment {
     public static void startManagingThread() {
         try {
             if (isManagingThread()) {
-                logger.warn("Thread already managed by Raven");
+                logger.log(Level.WARNING, "Thread already managed by Raven");
             }
         } finally {
             RAVEN_THREAD.get().incrementAndGet();
@@ -70,7 +69,7 @@ public final class RavenEnvironment {
             if (!isManagingThread()) {
                 //Start managing the thread only to send the warning
                 startManagingThread();
-                logger.warn("Thread not yet managed by Raven");
+                logger.log(Level.WARNING, "Thread not yet managed by Raven");
             }
         } finally {
             RAVEN_THREAD.get().decrementAndGet();

--- a/raven/src/main/java/com/getsentry/raven/event/EventBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/EventBuilder.java
@@ -2,8 +2,6 @@ package com.getsentry.raven.event;
 
 import com.getsentry.raven.environment.RavenEnvironment;
 import com.getsentry.raven.event.interfaces.SentryInterface;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.nio.charset.Charset;
@@ -11,6 +9,8 @@ import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
@@ -621,7 +621,7 @@ public class EventBuilder {
          * Time before the get hostname operation times out (in ms).
          */
         public static final long GET_HOSTNAME_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
-        private static final Logger logger = LoggerFactory.getLogger(HostnameCache.class);
+        private static final Logger logger = Logger.getLogger(HostnameCache.class.getName());
         /**
          * Time for which the cache is kept.
          */
@@ -666,13 +666,13 @@ public class EventBuilder {
             FutureTask<String> futureTask = new FutureTask<>(new HostRetriever());
             try {
                 new Thread(futureTask).start();
-                logger.debug("Updating the hostname cache");
+                logger.log(Level.FINE, "Updating the hostname cache");
                 hostname = futureTask.get(GET_HOSTNAME_TIMEOUT, TimeUnit.MILLISECONDS);
                 expirationTimestamp = System.currentTimeMillis() + cacheDuration;
             } catch (Exception e) {
                 futureTask.cancel(true);
                 expirationTimestamp = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(1);
-                logger.warn("Localhost hostname lookup failed, keeping the value '{}'", hostname, e);
+                logger.log(Level.WARNING, "Localhost hostname lookup failed, keeping the value '" + hostname + "'", e);
             }
         }
 

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -9,14 +9,14 @@ import com.getsentry.raven.event.Event;
 import com.getsentry.raven.event.interfaces.SentryInterface;
 import com.getsentry.raven.marshaller.Marshaller;
 import com.getsentry.raven.util.Util;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.DeflaterOutputStream;
 
 /**
@@ -114,7 +114,7 @@ public class JsonMarshaller implements Marshaller {
         }
     };
 
-    private static final Logger logger = LoggerFactory.getLogger(JsonMarshaller.class);
+    private static final Logger logger = Logger.getLogger(JsonMarshaller.class.getName());
     private final JsonFactory jsonFactory = new JsonFactory();
     private final Map<Class<? extends SentryInterface>, InterfaceBinding<?>> interfaceBindings = new HashMap<>();
     /**
@@ -154,12 +154,12 @@ public class JsonMarshaller implements Marshaller {
         try (JsonGenerator generator = jsonFactory.createGenerator(destination)) {
             writeContent(generator, event);
         } catch (IOException e) {
-            logger.error("An exception occurred while serialising the event.", e);
+            logger.log(Level.SEVERE, "An exception occurred while serialising the event.", e);
         } finally {
             try {
                 destination.close();
             } catch (IOException e) {
-                logger.error("An exception occurred while serialising the event.", e);
+                logger.log(Level.SEVERE, "An exception occurred while serialising the event.", e);
             }
         }
     }
@@ -198,8 +198,8 @@ public class JsonMarshaller implements Marshaller {
                 generator.writeFieldName(interfaceEntry.getKey());
                 getInterfaceBinding(sentryInterface).writeInterface(generator, interfaceEntry.getValue());
             } else {
-                logger.error("Couldn't parse the content of '{}' provided in {}.",
-                    interfaceEntry.getKey(), sentryInterface);
+                logger.log(Level.SEVERE, "Couldn't parse the content of '" + interfaceEntry.getKey()
+                        + "' provided in " + sentryInterface + ".");
             }
         }
     }
@@ -258,8 +258,8 @@ public class JsonMarshaller implements Marshaller {
                 /** @see com.fasterxml.jackson.core.JsonGenerator#_writeSimpleObject(Object)  */
                 generator.writeObject(value);
             } catch (IllegalStateException e) {
-                logger.debug("Couldn't marshal '{}' of type '{}', had to be converted into a String",
-                    value, value.getClass());
+                logger.log(Level.FINE, "Couldn't marshal '" + value + "' of type '" + value.getClass()
+                    + "', had to be converted into a String");
                 generator.writeString(value.toString());
             }
         }
@@ -367,8 +367,8 @@ public class JsonMarshaller implements Marshaller {
             case ERROR:
                 return "error";
             default:
-                logger.error("The level '{}' isn't supported, this should NEVER happen, contact Raven developers",
-                    level.name());
+                logger.log(Level.SEVERE, "The level '" + level.name()
+                    + "' isn't supported, this should NEVER happen, contact Raven developers");
                 return null;
         }
     }

--- a/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
+++ b/raven/src/main/java/com/getsentry/raven/servlet/RavenServletRequestListener.java
@@ -1,13 +1,13 @@
 package com.getsentry.raven.servlet;
 
 import com.getsentry.raven.Raven;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestEvent;
 import javax.servlet.ServletRequestListener;
 import javax.servlet.http.HttpServletRequest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Request listener in charge of capturing {@link HttpServletRequest} to allow
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletRequest;
  * in the event sent to Sentry.
  */
 public class RavenServletRequestListener implements ServletRequestListener {
-    private static final Logger logger = LoggerFactory.getLogger(RavenServletRequestListener.class);
+    private static final Logger logger = Logger.getLogger(RavenServletRequestListener.class.getName());
 
     private static final ThreadLocal<HttpServletRequest> THREAD_REQUEST = new ThreadLocal<>();
 
@@ -33,7 +33,7 @@ public class RavenServletRequestListener implements ServletRequestListener {
                 raven.getContext().clear();
             }
         } catch (Exception e) {
-            logger.error("Error clearing RavenContext state.", e);
+            logger.log(Level.SEVERE, "Error clearing RavenContext state.", e);
         }
     }
 


### PR DESCRIPTION
This is a branch off of `move-jul` #341 , it won't land on `master` until we merge `8.0`.

With this (and #341) we can drop the `slf4j` dependency from `raven` (core) and thus from `raven-android`.

I checked out some of the "best in class" Android libraries (e.g. [okhttp](https://github.com/square/okhttp)) and they are using `java.util.logging` because it's the only logging framework available without adding bloat.

The one unknown is whether I should add the [jul to slf4j bridge](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22jul-to-slf4j%22) to our other logging submodules, so that all `jul` logs are redirected over the user's logging framework of choice. This would usually be a bad thing for a general library to do, but since our dependencies *are* logging related it seems like it might be the correct thing. In other words, if someone is using `raven-logback` it's because they are definitely using `logback` and so it should be safe to push all `jul` logs over that way...