### PR TITLE
Drop needless javax.annotations.Nullable usages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
 
         <!-- dependencies versions -->
         <slf4j.version>1.7.24</slf4j.version>
-        <findbugs.version>3.0.1</findbugs.version>
         <jackson.version>2.8.7</jackson.version>
         <jmockit.version>1.14</jmockit.version>
         <testng.version>6.9.10</testng.version>
@@ -144,11 +143,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${findbugs.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/raven/pom.xml
+++ b/raven/pom.xml
@@ -24,11 +24,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/raven/src/main/java/com/getsentry/raven/event/interfaces/MessageInterface.java
+++ b/raven/src/main/java/com/getsentry/raven/event/interfaces/MessageInterface.java
@@ -1,6 +1,5 @@
 package com.getsentry.raven.event.interfaces;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,7 +30,7 @@ public class MessageInterface implements SentryInterface {
     public static final String MESSAGE_INTERFACE = "sentry.interfaces.Message";
     private final String message;
     private final List<String> parameters;
-    @Nullable private final String formatted;
+    private final String formatted;
 
     /**
      * Creates a non parametrised message.

--- a/raven/src/main/java/com/getsentry/raven/util/Util.java
+++ b/raven/src/main/java/com/getsentry/raven/util/Util.java
@@ -1,6 +1,5 @@
 package com.getsentry.raven.util;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -24,7 +23,7 @@ public final class Util {
      * @param string a string reference to check
      * @return {@code true} if the string is null or is the empty string
      */
-    public static boolean isNullOrEmpty(@Nullable String string) {
+    public static boolean isNullOrEmpty(String string) {
         return string == null || string.length() == 0; // string.isEmpty() in Java 6
     }
 


### PR DESCRIPTION
The `jsr305` was providing the "implementation" of the annotation.

"In practice this annotation is useful only for overriding an overarching NonNull annotation." http://findbugs.sourceforge.net/manual/annotations.html

We don't use `@NonNull`...

This spares us another Proguard exclusion (`-dontwarn javax.annotations.Nullable`) for 2 usages of `Nullable` throughout the codebase.



