### PR TITLE
Change Breadcrumb type and level to enums, add more sensible defaults.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Version 8.0.0
 - Fix so that system properties and environment variables always override hardcoded logger configuration for settings
   such as release, environment, etc.
 - Fix Raven initialization so that slf4j doesn't emit log replay warning on startup.
+- Changed ``Breadcrumb`` and `BreadcrumbBuilder`` to use enums for some fields.
 
 Version 7.8.6
 -------------

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
@@ -12,9 +12,13 @@ import java.util.Map;
 public class Breadcrumb implements Serializable {
 
     /**
+     * Default category.
+     */
+    private static final String DEFAULT_CATEGORY = "generic";
+    /**
      * (Optional) Type of the breadcrumb.
      */
-    private final String type;
+    private final Type type;
     /**
      * Timestamp when the breadcrumb occurred.
      */
@@ -22,7 +26,7 @@ public class Breadcrumb implements Serializable {
     /**
      * Level of the breadcrumb.
      */
-    private final String level;
+    private final Level level;
     /**
      * Message of the breadcrumb.
      */
@@ -37,24 +41,82 @@ public class Breadcrumb implements Serializable {
     private final Map<String, String> data;
 
     /**
+     * Possible choices for the level field.
+     */
+    public enum Level {
+        /**
+         * DEBUG level.
+         */
+        DEBUG,
+
+        /**
+         * INFO level.
+         */
+        INFO,
+
+        /**
+         * WARNING level.
+         */
+        WARNING,
+
+        /**
+         * ERROR level.
+         */
+        ERROR,
+
+        /**
+         * CRITICAL level.
+         */
+        CRITICAL
+    }
+    /**
+     * Possible choices for the type field.
+     */
+    public enum Type {
+        /**
+         * DEFAULT type.
+         */
+        DEFAULT,
+
+        /**
+         * HTTP type.
+         */
+        HTTP,
+
+        /**
+         * NAVIGATION type.
+         */
+        NAVIGATION
+    }
+
+    /**
      * Create an immutable {@link Breadcrumb} object.
      *
-     * @param type String
+     * @param type Type
      * @param timestamp Date
-     * @param level String
+     * @param level Level
      * @param message String
      * @param category String
      * @param data Map of String to String
      */
-    Breadcrumb(String type, Date timestamp, String level, String message,
+    Breadcrumb(Type type, Date timestamp, Level level, String message,
         String category, Map<String, String> data) {
 
         if (timestamp == null) {
             timestamp = new Date();
         }
 
-        checkNotNull(level, "level");
-        checkNotNull(category, "category");
+        if (category == null) {
+            category = DEFAULT_CATEGORY;
+        }
+
+        if (level == null) {
+            level = Level.INFO;
+        }
+
+        if (type == null) {
+            type = Type.DEFAULT;
+        }
 
         if (message == null && (data == null || data.size() < 1)) {
             throw new IllegalArgumentException("one of 'message' or 'data' must be set");
@@ -74,7 +136,7 @@ public class Breadcrumb implements Serializable {
         }
     }
 
-    public String getType() {
+    public Type getType() {
         return type;
     }
 
@@ -82,7 +144,7 @@ public class Breadcrumb implements Serializable {
         return timestamp;
     }
 
-    public String getLevel() {
+    public Level getLevel() {
         return level;
     }
 

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
@@ -67,6 +67,11 @@ public class Breadcrumb implements Serializable {
 
         private final String value;
 
+        /**
+         * Construct a {@link Level} with the value to serialize with.
+         *
+         * @param value Value to use for serialization.
+         */
         Level(String value) {
             this.value = value;
         }
@@ -96,6 +101,11 @@ public class Breadcrumb implements Serializable {
 
         private final String value;
 
+        /**
+         * Construct a {@link Type} with the value to serialize with.
+         *
+         * @param value Value to use for serialization.
+         */
         Type(String value) {
             this.value = value;
         }

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
@@ -12,10 +12,6 @@ import java.util.Map;
 public class Breadcrumb implements Serializable {
 
     /**
-     * Default category.
-     */
-    private static final String DEFAULT_CATEGORY = "generic";
-    /**
      * (Optional) Type of the breadcrumb.
      */
     private final Type type;
@@ -47,27 +43,37 @@ public class Breadcrumb implements Serializable {
         /**
          * DEBUG level.
          */
-        DEBUG,
+        DEBUG("debug"),
 
         /**
          * INFO level.
          */
-        INFO,
+        INFO("info"),
 
         /**
          * WARNING level.
          */
-        WARNING,
+        WARNING("warning"),
 
         /**
          * ERROR level.
          */
-        ERROR,
+        ERROR("error"),
 
         /**
          * CRITICAL level.
          */
-        CRITICAL
+        CRITICAL("critical");
+
+        private final String value;
+
+        Level(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
     }
     /**
      * Possible choices for the type field.
@@ -76,17 +82,27 @@ public class Breadcrumb implements Serializable {
         /**
          * DEFAULT type.
          */
-        DEFAULT,
+        DEFAULT("default"),
 
         /**
          * HTTP type.
          */
-        HTTP,
+        HTTP("http"),
 
         /**
          * NAVIGATION type.
          */
-        NAVIGATION
+        NAVIGATION("navigation");
+
+        private final String value;
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
     }
 
     /**
@@ -106,18 +122,6 @@ public class Breadcrumb implements Serializable {
             timestamp = new Date();
         }
 
-        if (category == null) {
-            category = DEFAULT_CATEGORY;
-        }
-
-        if (level == null) {
-            level = Level.INFO;
-        }
-
-        if (type == null) {
-            type = Type.DEFAULT;
-        }
-
         if (message == null && (data == null || data.size() < 1)) {
             throw new IllegalArgumentException("one of 'message' or 'data' must be set");
         }
@@ -128,12 +132,6 @@ public class Breadcrumb implements Serializable {
         this.message = message;
         this.category = category;
         this.data = data;
-    }
-
-    private void checkNotNull(String str, String name) {
-        if (str == null) {
-            throw new IllegalArgumentException("field '" + name + "' is required but got null");
-        }
     }
 
     public Type getType() {

--- a/raven/src/main/java/com/getsentry/raven/event/BreadcrumbBuilder.java
+++ b/raven/src/main/java/com/getsentry/raven/event/BreadcrumbBuilder.java
@@ -8,9 +8,9 @@ import java.util.Map;
  */
 public class BreadcrumbBuilder {
 
-    private String type;
+    private Breadcrumb.Type type;
     private Date timestamp;
-    private String level;
+    private Breadcrumb.Level level;
     private String message;
     private String category;
     private Map<String, String> data;
@@ -18,10 +18,10 @@ public class BreadcrumbBuilder {
     /**
      * Type of the {@link Breadcrumb}.
      *
-     * @param newType String
+     * @param newType {@link Breadcrumb.Type}
      * @return current BreadcrumbBuilder
      */
-    public BreadcrumbBuilder setType(String newType) {
+    public BreadcrumbBuilder setType(Breadcrumb.Type newType) {
         this.type = newType;
         return this;
     }
@@ -40,10 +40,10 @@ public class BreadcrumbBuilder {
     /**
      * Level of the {@link Breadcrumb}.
      *
-     * @param newLevel String
+     * @param newLevel {@link Breadcrumb.Level}
      * @return current BreadcrumbBuilder
      */
-    public BreadcrumbBuilder setLevel(String newLevel) {
+    public BreadcrumbBuilder setLevel(Breadcrumb.Level newLevel) {
         this.level = newLevel;
         return this;
     }

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -294,10 +294,10 @@ public class JsonMarshaller implements Marshaller {
             generator.writeNumberField("timestamp", breadcrumb.getTimestamp().getTime() / 1000);
 
             if (breadcrumb.getType() != null) {
-                generator.writeStringField("type", breadcrumb.getType().name().toLowerCase());
+                generator.writeStringField("type", breadcrumb.getType().getValue());
             }
             if (breadcrumb.getLevel() != null) {
-                generator.writeStringField("level", breadcrumb.getLevel().name().toLowerCase());
+                generator.writeStringField("level", breadcrumb.getLevel().getValue());
             }
             if (breadcrumb.getMessage() != null) {
                 generator.writeStringField("message", breadcrumb.getMessage());

--- a/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/com/getsentry/raven/marshaller/json/JsonMarshaller.java
@@ -294,10 +294,10 @@ public class JsonMarshaller implements Marshaller {
             generator.writeNumberField("timestamp", breadcrumb.getTimestamp().getTime() / 1000);
 
             if (breadcrumb.getType() != null) {
-                generator.writeStringField("type", breadcrumb.getType());
+                generator.writeStringField("type", breadcrumb.getType().name().toLowerCase());
             }
             if (breadcrumb.getLevel() != null) {
-                generator.writeStringField("level", breadcrumb.getLevel());
+                generator.writeStringField("level", breadcrumb.getLevel().name().toLowerCase());
             }
             if (breadcrumb.getMessage() != null) {
                 generator.writeStringField("message", breadcrumb.getMessage());

--- a/raven/src/test/java/com/getsentry/raven/ContextTest.java
+++ b/raven/src/test/java/com/getsentry/raven/ContextTest.java
@@ -22,7 +22,7 @@ public class ContextTest {
         Context context = new Context();
 
         Breadcrumb breadcrumb = new BreadcrumbBuilder()
-            .setLevel("info")
+            .setLevel(Breadcrumb.Level.INFO)
             .setCategory("foo")
             .setMessage("test")
             .build();
@@ -45,12 +45,12 @@ public class ContextTest {
         Context context = new Context(1);
 
         Breadcrumb breadcrumb1 = new BreadcrumbBuilder()
-            .setLevel("info")
+            .setLevel(Breadcrumb.Level.INFO)
             .setCategory("foo")
             .setMessage("test1")
             .build();
         Breadcrumb breadcrumb2 = new BreadcrumbBuilder()
-            .setLevel("info")
+            .setLevel(Breadcrumb.Level.INFO)
             .setCategory("foo")
             .setMessage("test2")
             .build();

--- a/raven/src/test/java/com/getsentry/raven/buffer/DiskBufferTest.java
+++ b/raven/src/test/java/com/getsentry/raven/buffer/DiskBufferTest.java
@@ -36,11 +36,7 @@ public class DiskBufferTest extends BufferTest {
 
     @Test
     public void testAddAndDiscard() throws IOException {
-        Breadcrumb breadcrumb = new BreadcrumbBuilder()
-                .setLevel("INFO")
-                .setCategory("CATEGORY")
-                .setMessage("MESSAGE")
-                .build();
+        Breadcrumb breadcrumb = new BreadcrumbBuilder().setMessage("MESSAGE").build();
         List<Breadcrumb> breadcrumbs = Lists.newArrayList();
         breadcrumbs.add(breadcrumb);
 

--- a/raven/src/test/java/com/getsentry/raven/event/BreadcrumbTest.java
+++ b/raven/src/test/java/com/getsentry/raven/event/BreadcrumbTest.java
@@ -35,7 +35,7 @@ public class BreadcrumbTest {
         raven.addBuilderHelper(new ContextBuilderHelper(raven));
 
         final Breadcrumb breadcrumb = new BreadcrumbBuilder()
-            .setLevel("info")
+            .setLevel(Breadcrumb.Level.INFO)
             .setMessage("message")
             .setCategory("step")
             .build();
@@ -58,7 +58,7 @@ public class BreadcrumbTest {
         raven.addBuilderHelper(new ContextBuilderHelper(raven));
 
         final Breadcrumb breadcrumb = new BreadcrumbBuilder()
-            .setLevel("info")
+            .setLevel(Breadcrumb.Level.INFO)
             .setMessage("message")
             .setCategory("step")
             .build();
@@ -83,7 +83,7 @@ public class BreadcrumbTest {
         raven.addBuilderHelper(new ContextBuilderHelper(raven));
 
         final Breadcrumb breadcrumb = new BreadcrumbBuilder()
-            .setLevel("info")
+            .setLevel(Breadcrumb.Level.INFO)
             .setMessage("message")
             .setCategory("step")
             .build();

--- a/raven/src/test/java/com/getsentry/raven/marshaller/json/JsonMarshallerTest.java
+++ b/raven/src/test/java/com/getsentry/raven/marshaller/json/JsonMarshallerTest.java
@@ -237,13 +237,13 @@ public class JsonMarshallerTest {
 
         Breadcrumb breadcrumb1 = new BreadcrumbBuilder()
             .setTimestamp(new Date(1463169342000L))
-            .setLevel("info")
+            .setLevel(Breadcrumb.Level.INFO)
             .setCategory("foo")
             .setMessage("test1")
             .build();
         Breadcrumb breadcrumb2 = new BreadcrumbBuilder()
             .setTimestamp(new Date(1463169343000L))
-            .setLevel("info")
+            .setLevel(Breadcrumb.Level.INFO)
             .setCategory("foo")
             .setMessage("test2")
             .build();

--- a/raven/src/test/resources/com/getsentry/raven/marshaller/json/jsonmarshallertest/testBreadcrumbs.json
+++ b/raven/src/test/resources/com/getsentry/raven/marshaller/json/jsonmarshallertest/testBreadcrumbs.json
@@ -14,8 +14,8 @@
     "checksum": null,
     "breadcrumbs": {
         "values": [
-            {"timestamp":1463169342,"level":"info","message":"test1","category":"foo","type":"default"},
-            {"timestamp":1463169343,"level":"info","message":"test2","category":"foo","type":"default"}
+            {"timestamp":1463169342,"level":"info","message":"test1","category":"foo"},
+            {"timestamp":1463169343,"level":"info","message":"test2","category":"foo"}
         ]
     },
     "sdk": {

--- a/raven/src/test/resources/com/getsentry/raven/marshaller/json/jsonmarshallertest/testBreadcrumbs.json
+++ b/raven/src/test/resources/com/getsentry/raven/marshaller/json/jsonmarshallertest/testBreadcrumbs.json
@@ -14,8 +14,8 @@
     "checksum": null,
     "breadcrumbs": {
         "values": [
-            {"timestamp":1463169342,"level":"info","message":"test1","category":"foo"},
-            {"timestamp":1463169343,"level":"info","message":"test2","category":"foo"}
+            {"timestamp":1463169342,"level":"info","message":"test1","category":"foo","type":"default"},
+            {"timestamp":1463169343,"level":"info","message":"test2","category":"foo","type":"default"}
         ]
     },
     "sdk": {


### PR DESCRIPTION
One more cleanup thing that I think belongs in 8.0. While documenting I thought the strings were a pretty poor interface.

I highly doubt anyone was using this since Context was pretty busted up.