### PR TITLE
Initialize Raven ASAP in logging integrations.

### DIFF
--- a/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
@@ -93,7 +93,7 @@ public class SentryAppender extends AppenderSkeleton {
      * Creates an instance of SentryAppender.
      */
     public SentryAppender() {
-        this.addFilter(new DropRavenFilter());
+        this(null);
     }
 
     /**
@@ -102,8 +102,12 @@ public class SentryAppender extends AppenderSkeleton {
      * @param raven instance of Raven to use with this appender.
      */
     public SentryAppender(Raven raven) {
-        this();
-        this.raven = raven;
+        this.addFilter(new DropRavenFilter());
+        if (raven == null) {
+            initRaven();
+        } else {
+            this.raven = raven;
+        }
     }
 
     /**
@@ -195,8 +199,6 @@ public class SentryAppender extends AppenderSkeleton {
     @Override
     public void activateOptions() {
         super.activateOptions();
-
-        lazyInit();
     }
 
     /**
@@ -220,6 +222,11 @@ public class SentryAppender extends AppenderSkeleton {
 
     @Override
     protected void append(LoggingEvent loggingEvent) {
+        lazyInit();
+        if (raven == null) {
+            return;
+        }
+
         // Do not log the event if the current thread is managed by raven
         if (RavenEnvironment.isManagingThread()) {
             return;
@@ -227,7 +234,6 @@ public class SentryAppender extends AppenderSkeleton {
 
         RavenEnvironment.startManagingThread();
         try {
-            lazyInit();
             Event event = buildEvent(loggingEvent);
             raven.sendEvent(event);
         } catch (Exception e) {

--- a/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
@@ -196,15 +196,10 @@ public class SentryAppender extends AppenderSkeleton {
         return new StackTraceElement(location.getClassName(), location.getMethodName(), fileName, line);
     }
 
-    @Override
-    public void activateOptions() {
-        super.activateOptions();
-    }
-
     /**
      * Initialises the Raven instance.
      */
-    protected synchronized void initRaven() {
+    protected void initRaven() {
         try {
             if (dsn == null) {
                 dsn = Dsn.dsnLookup();

--- a/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
@@ -121,11 +121,6 @@ public class SentryAppender extends AppenderSkeleton {
             synchronized (this) {
                 if (!initialized) {
                     try {
-                        String ravenFactory = Lookup.lookup("ravenFactory");
-                        if (ravenFactory != null) {
-                            setRavenFactory(ravenFactory);
-                        }
-
                         String release = Lookup.lookup("release");
                         if (release != null) {
                             setRelease(release);
@@ -203,6 +198,11 @@ public class SentryAppender extends AppenderSkeleton {
         try {
             if (dsn == null) {
                 dsn = Dsn.dsnLookup();
+            }
+
+            String ravenFactory = Lookup.lookup("ravenFactory");
+            if (ravenFactory != null) {
+                setRavenFactory(ravenFactory);
             }
 
             raven = RavenFactory.ravenInstance(new Dsn(dsn), ravenFactory);

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -311,7 +311,7 @@ public class SentryAppender extends AbstractAppender {
     /**
      * Initialises the Raven instance.
      */
-    protected synchronized void initRaven() {
+    protected void initRaven() {
         try {
             if (dsn == null) {
                 dsn = Dsn.dsnLookup();

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -200,11 +200,6 @@ public class SentryAppender extends AbstractAppender {
             synchronized (this) {
                 if (!initialized) {
                     try {
-                        String ravenFactory = Lookup.lookup("ravenFactory");
-                        if (ravenFactory != null) {
-                            setRavenFactory(ravenFactory);
-                        }
-
                         String release = Lookup.lookup("release");
                         if (release != null) {
                             setRelease(release);
@@ -315,6 +310,11 @@ public class SentryAppender extends AbstractAppender {
         try {
             if (dsn == null) {
                 dsn = Dsn.dsnLookup();
+            }
+
+            String ravenFactory = Lookup.lookup("ravenFactory");
+            if (ravenFactory != null) {
+                setRavenFactory(ravenFactory);
             }
 
             raven = RavenFactory.ravenInstance(new Dsn(dsn), ravenFactory);

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -120,7 +120,8 @@ public class SentryAppender extends AbstractAppender {
      * @param raven instance of Raven to use with this appender.
      */
     public SentryAppender(Raven raven) {
-        this();
+        super(APPENDER_NAME, null, null, true);
+        this.addFilter(new DropRavenFilter());
         this.raven = raven;
     }
 
@@ -133,6 +134,7 @@ public class SentryAppender extends AbstractAppender {
     protected SentryAppender(String name, Filter filter) {
         super(name, filter, null, true);
         this.addFilter(new DropRavenFilter());
+        initRaven();
     }
 
     /**
@@ -285,6 +287,11 @@ public class SentryAppender extends AbstractAppender {
      */
     @Override
     public void append(LogEvent logEvent) {
+        lazyInit();
+        if (raven == null) {
+            return;
+        }
+
         // Do not log the event if the current thread is managed by raven
         if (RavenEnvironment.isManagingThread()) {
             return;
@@ -292,7 +299,6 @@ public class SentryAppender extends AbstractAppender {
 
         RavenEnvironment.startManagingThread();
         try {
-            lazyInit();
             Event event = buildEvent(logEvent);
             raven.sendEvent(event);
         } catch (Exception e) {

--- a/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
@@ -247,7 +247,7 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
     /**
      * Initialises the Raven instance.
      */
-    protected synchronized void initRaven() {
+    protected void initRaven() {
         try {
             if (dsn == null) {
                 dsn = Dsn.dsnLookup();

--- a/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
@@ -133,11 +133,6 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
             synchronized (this) {
                 if (!initialized) {
                     try {
-                        String ravenFactory = Lookup.lookup("ravenFactory");
-                        if (ravenFactory != null) {
-                            setRavenFactory(ravenFactory);
-                        }
-
                         String release = Lookup.lookup("release");
                         if (release != null) {
                             setRelease(release);
@@ -251,6 +246,11 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         try {
             if (dsn == null) {
                 dsn = Dsn.dsnLookup();
+            }
+
+            String ravenFactory = Lookup.lookup("ravenFactory");
+            if (ravenFactory != null) {
+                setRavenFactory(ravenFactory);
             }
 
             raven = RavenFactory.ravenInstance(new Dsn(dsn), ravenFactory);

--- a/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
@@ -105,7 +105,7 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      * Creates an instance of SentryAppender.
      */
     public SentryAppender() {
-        this.addFilter(new DropRavenFilter());
+        this(null);
     }
 
     /**
@@ -114,8 +114,12 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      * @param raven instance of Raven to use with this appender.
      */
     public SentryAppender(Raven raven) {
-        this();
-        this.raven = raven;
+        this.addFilter(new DropRavenFilter());
+        if (raven == null) {
+            initRaven();
+        } else {
+            this.raven = raven;
+        }
     }
 
     /**
@@ -215,6 +219,11 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      */
     @Override
     protected void append(ILoggingEvent iLoggingEvent) {
+        lazyInit();
+        if (raven == null) {
+            return;
+        }
+
         // Do not log the event if the current thread is managed by raven
         if (RavenEnvironment.isManagingThread()) {
             return;
@@ -226,7 +235,6 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
                 return;
             }
 
-            lazyInit();
             Event event = buildEvent(iLoggingEvent);
             raven.sendEvent(event);
         } catch (Exception e) {

--- a/raven/src/main/java/com/getsentry/raven/Raven.java
+++ b/raven/src/main/java/com/getsentry/raven/Raven.java
@@ -193,10 +193,16 @@ public class Raven {
      * @return statically stored {@link Raven} instance
      */
     public static Raven getStoredInstance() {
+        // This trace is important because for some logging frameworks it will cause the appender
+        // to be initialized, which should fill in the stored Raven instance.
+        logger.trace("Retrieving stored instance.");
         return stored;
     }
 
     private static void verifyStoredInstance() {
+        // This trace is important because for some logging frameworks it will cause the appender
+        // to be initialized, which should fill in the stored Raven instance.
+        logger.trace("Verifying stored instance.");
         if (stored == null) {
             throw new NullPointerException("No stored Raven instance is available to use."
                 + " You must construct a Raven instance before using the static Raven methods.");

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -124,12 +124,7 @@ public class SentryHandler extends Handler {
         if (!initialized) {
             synchronized (this) {
                 if (!initialized) {
-
                     try {
-                        String ravenFactory = Lookup.lookup("ravenFactory");
-                        if (ravenFactory != null) {
-                            setRavenFactory(ravenFactory);
-                        }
 
                         String release = Lookup.lookup("release");
                         if (release != null) {
@@ -270,6 +265,11 @@ public class SentryHandler extends Handler {
         try {
             if (dsn == null) {
                 dsn = Dsn.dsnLookup();
+            }
+
+            String ravenFactory = Lookup.lookup("ravenFactory");
+            if (ravenFactory != null) {
+                setRavenFactory(ravenFactory);
             }
 
             raven = RavenFactory.ravenInstance(new Dsn(dsn), ravenFactory);

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -266,7 +266,7 @@ public class SentryHandler extends Handler {
     /**
      * Initialises the Raven instance.
      */
-    protected synchronized void initRaven() {
+    protected void initRaven() {
         try {
             if (dsn == null) {
                 dsn = Dsn.dsnLookup();


### PR DESCRIPTION
This is part 2 of #365.

In short:

1. Always create a `raven` instance in the Appender constructors, so that it is available ASAP.
2. Trace log when accessing the shared `raven` instance... because log4j2 doesn't even attempt to make the appenders until it sees a log line.

The issue is that it brings back the same issue from #354, and I don't see a way around it. As a reminder, #354 meant messages like these *always* occurred on init:

```
SLF4J: A number (7) of logging calls during the initialization phase have been intercepted and are
SLF4J: now being replayed. These are subject to the filtering rules of the underlying logging system.
SLF4J: See also http://www.slf4j.org/codes.html#replay
```

I don't know how we can have our cake and eat it too...

(I need to fix tests too, but I tried this with all logging integrations manually to prove it allows for setting breadcrumbs before logging at all)