### PR TITLE
Fix message interface errors in log4j2 integration.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Version 8.0.1
 -------------
 
--
+- Fix message interface errors in log4j2 integration.
 
 Version 8.0.0
 -------------

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -347,7 +347,9 @@ public class SentryAppender extends AbstractAppender {
             eventBuilder.withEnvironment(environment.trim());
         }
 
-        if (!eventMessage.getFormattedMessage().equals(eventMessage.getFormat())) {
+        if (eventMessage.getFormat() != null
+            && !eventMessage.getFormat().equals("")
+            && !eventMessage.getFormattedMessage().equals(eventMessage.getFormat())) {
             eventBuilder.withSentryInterface(new MessageInterface(
                 eventMessage.getFormat(),
                 formatMessageParameters(eventMessage.getParameters()),


### PR DESCRIPTION
Apparently getFormat() can (and does) return an empty string in some
cases. This would cause a `null` format string with parameters and
display as an Event/JSON issue in the Sentry UI. This fixes the log4j2
integration to only include the parameterized message information if
getFormat() returns something useful.