### PR TITLE
Fix setting the ``RavenFactory`` via Java System Properties or enviro…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Version 8.0.1
 -------------
 
--
+- Fix setting the ``RavenFactory`` via Java System Properties or environment variables.
 
 Version 8.0.0
 -------------

--- a/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/com/getsentry/raven/log4j/SentryAppender.java
@@ -113,10 +113,6 @@ public class SentryAppender extends AppenderSkeleton {
      */
     @SuppressWarnings("checkstyle:hiddenfield")
     private void lazyInit() {
-        if (raven == null) {
-            initRaven();
-        }
-
         if (!initialized) {
             synchronized (this) {
                 if (!initialized) {
@@ -155,6 +151,10 @@ public class SentryAppender extends AppenderSkeleton {
                     }
                 }
             }
+        }
+
+        if (raven == null) {
+            initRaven();
         }
     }
 

--- a/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
+++ b/raven-log4j2/src/main/java/com/getsentry/raven/log4j2/SentryAppender.java
@@ -194,10 +194,6 @@ public class SentryAppender extends AbstractAppender {
      */
     @SuppressWarnings("checkstyle:hiddenfield")
     private void lazyInit() {
-        if (raven == null) {
-            initRaven();
-        }
-
         if (!initialized) {
             synchronized (this) {
                 if (!initialized) {
@@ -236,6 +232,10 @@ public class SentryAppender extends AbstractAppender {
                     }
                 }
             }
+        }
+
+        if (raven == null) {
+            initRaven();
         }
     }
 

--- a/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+++ b/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
@@ -125,10 +125,6 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      */
     @SuppressWarnings("checkstyle:hiddenfield")
     private void lazyInit() {
-        if (raven == null) {
-            initRaven();
-        }
-
         if (!initialized) {
             synchronized (this) {
                 if (!initialized) {
@@ -167,6 +163,10 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
                     }
                 }
             }
+        }
+
+        if (raven == null) {
+            initRaven();
         }
     }
 

--- a/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
+++ b/raven/src/main/java/com/getsentry/raven/jul/SentryHandler.java
@@ -117,10 +117,6 @@ public class SentryHandler extends Handler {
      */
     @SuppressWarnings("checkstyle:hiddenfield")
     private void lazyInit() {
-        if (raven == null) {
-            initRaven();
-        }
-
         if (!initialized) {
             synchronized (this) {
                 if (!initialized) {
@@ -160,6 +156,10 @@ public class SentryHandler extends Handler {
                     }
                 }
             }
+        }
+
+        if (raven == null) {
+            initRaven();
         }
     }
 


### PR DESCRIPTION
…nment variables.

Ugh, these logging framework integrations are so hard to test, especially RE: global state like System props & env vars.

`initRaven` needs to be called *after* we do variable lookups because one of the possible variables they can set is the `RavenFactory` used by `initRaven`...