### PR TITLE
Add "user" to Breadcrumb.Type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Version 8.0.2
 -------------
 
--
+- Add `USER` option to the `Breadcrumb.Type` enum.
 
 Version 8.0.1
 -------------

--- a/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
+++ b/raven/src/main/java/com/getsentry/raven/event/Breadcrumb.java
@@ -97,7 +97,13 @@ public class Breadcrumb implements Serializable {
         /**
          * NAVIGATION type.
          */
-        NAVIGATION("navigation");
+        NAVIGATION("navigation"),
+
+        /**
+         * USER type.
+         */
+        USER("user");
+
 
         private final String value;
 


### PR DESCRIPTION
Version 8.0.0 changed the breadcrumb type from a string into an enum (which I fully support), but it does not include a type called "user". The reason I think there should be one is that the web interface defines an icon for it (and that I was using it in a Sentry client):

![user_breadcrumb](https://cloud.githubusercontent.com/assets/6951068/24831553/0e0e1492-1c9c-11e7-9fff-87d628322754.png)

Let me know if you agree with this addition.
