### PR TITLE
Add way to set release, environment, serverName, tags on SentryClient.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Version 1.0.0
 - Add ``dist`` field to Event.
 - Compressed JSON payloads are no longer base64 encoded.
 - Rename ``EventSendFailureCallback`` to ``EventSendCallback``, add ``onSuccess`` callback.
+- Add way to set release, environment, serverName, tags on ``SentryClient``.
 
 Version 8.0.2
 -------------

--- a/sentry/src/test/java/io/sentry/SentryClientTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.java
@@ -15,6 +15,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -155,5 +157,36 @@ public class SentryClientTest {
         }};
 
         sentryClient.closeConnection();
+    }
+
+    @Test
+    public void testFields() throws Exception {
+        sentryClient.addBuilderHelper(mockEventBuilderHelper);
+
+        final String serverName = "serverName";
+        sentryClient.setServerName(serverName);
+        final String environment = "environment";
+        sentryClient.setEnvironment(environment);
+        final String dist = "dist";
+        sentryClient.setDist(dist);
+        final String release = "release";
+        sentryClient.setRelease(release);
+        final Map<String, String> tags = new HashMap<>();
+        tags.put("name", "value");
+        sentryClient.setTags(tags);
+
+        sentryClient.sendMessage("message");
+
+        new Verifications() {{
+            Event event;
+            mockEventBuilderHelper.helpBuildingEvent((EventBuilder) any);
+            mockConnection.send(event = withCapture());
+            assertThat(event.getLevel(), equalTo(Event.Level.INFO));
+            assertThat(event.getServerName(), equalTo(serverName));
+            assertThat(event.getEnvironment(), equalTo(environment));
+            assertThat(event.getDist(), equalTo(dist));
+            assertThat(event.getRelease(), equalTo(release));
+            assertThat(event.getTags(), equalTo(tags));
+        }};
     }
 }


### PR DESCRIPTION
This adds useful methods to the `SentryClient`

Roughly:

```
client = Sentry.init(dsn)
client.setRelease(1.0)
client.setEnvironment(production)
client.addTag(crappy_phone, true)
client.addEventCallback(mycallback)

// later, this should attach all the data and use the callback
Sentry.capture(exception)
```

@mitsuhiko you had asked about ways to set the other fields (env, release, tags, etc) too I think?