### PR TITLE
Make Context and User classes serializable

### DIFF
--- a/raven/src/main/java/com/getsentry/raven/context/Context.java
+++ b/raven/src/main/java/com/getsentry/raven/context/Context.java
@@ -3,6 +3,8 @@ package com.getsentry.raven.context;
 import com.getsentry.raven.event.Breadcrumb;
 import com.getsentry.raven.event.User;
 import com.getsentry.raven.util.CircularFifoQueue;
+
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.UUID;
 
@@ -11,7 +13,7 @@ import java.util.UUID;
  * so that data may be collected in different parts of an application and
  * then sent together when an exception occurs.
  */
-public class Context {
+public class Context implements Serializable {
     /**
      * The number of {@link Breadcrumb}s to keep in the ring buffer by default.
      */

--- a/raven/src/main/java/com/getsentry/raven/event/User.java
+++ b/raven/src/main/java/com/getsentry/raven/event/User.java
@@ -1,12 +1,14 @@
 package com.getsentry.raven.event;
 
 
+import java.io.Serializable;
+
 /**
  * An object that represents a user. Typically used to represent
  * the user in the current context, for whatever a context means
  * in your application (typically a web request).
  */
-public class User {
+public class User implements Serializable {
 
     private final String id;
     private final String username;


### PR DESCRIPTION
For custom implementations of ContextManager it is required that Context object can be serialized.