### PR TITLE
Change Appenders to create an EventBuilder rather than an Event, unif…

### DIFF
--- a/sentry-log4j/src/main/java/io/sentry/log4j/SentryAppender.java
+++ b/sentry-log4j/src/main/java/io/sentry/log4j/SentryAppender.java
@@ -239,8 +239,8 @@ public class SentryAppender extends AppenderSkeleton {
         SentryEnvironment.startManagingThread();
         try {
             lazyInit();
-            Event event = buildEvent(loggingEvent);
-            sentryClient.sendEvent(event);
+            EventBuilder eventBuilder = createEventBuilder(loggingEvent);
+            sentryClient.sendEvent(eventBuilder);
         } catch (Exception e) {
             getErrorHandler().error("An exception occurred while creating a new event in Sentry", e,
                     ErrorCode.WRITE_FAILURE);
@@ -250,12 +250,12 @@ public class SentryAppender extends AppenderSkeleton {
     }
 
     /**
-     * Builds an Event based on the logging event.
+     * Builds an EventBuilder based on the logging event.
      *
      * @param loggingEvent Log generated.
-     * @return Event containing details provided by the logging system.
+     * @return EventBuilder containing details provided by the logging system.
      */
-    protected Event buildEvent(LoggingEvent loggingEvent) {
+    protected EventBuilder createEventBuilder(LoggingEvent loggingEvent) {
         EventBuilder eventBuilder = new EventBuilder()
             .withSdkName(SentryEnvironment.SDK_NAME + ":log4j")
             .withTimestamp(new Date(loggingEvent.getTimeStamp()))
@@ -323,8 +323,7 @@ public class SentryAppender extends AppenderSkeleton {
             eventBuilder.withTag(tagEntry.getKey(), tagEntry.getValue());
         }
 
-        sentryClient.runBuilderHelpers(eventBuilder);
-        return eventBuilder.build();
+        return eventBuilder;
     }
 
     public void setFactory(String factory) {

--- a/sentry-log4j/src/test/java/io/sentry/log4j/SentryAppenderEventBuildingTest.java
+++ b/sentry-log4j/src/test/java/io/sentry/log4j/SentryAppenderEventBuildingTest.java
@@ -65,9 +65,9 @@ public class SentryAppenderEventBuildingTest {
                 null, null, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getMessage(), is(message));
             assertThat(event.getLogger(), is(loggerName));
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(SentryAppender.THREAD_NAME, threadName));
@@ -93,8 +93,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new LoggingEvent(null, mockLogger, 0, level, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getLevel(), is(expectedLevel));
         }};
         assertNoErrorsInErrorHandler();
@@ -107,8 +108,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new LoggingEvent(null, mockLogger, 0, Level.ERROR, null, exception));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             ExceptionInterface exceptionInterface = (ExceptionInterface) event.getSentryInterfaces()
                     .get(ExceptionInterface.EXCEPTION_INTERFACE);
             SentryException sentryException = exceptionInterface.getExceptions().getFirst();
@@ -128,8 +130,9 @@ public class SentryAppenderEventBuildingTest {
                 null, null, null, Collections.singletonMap(extraKey, extraValue)));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(extraKey, extraValue));
         }};
         assertNoErrorsInErrorHandler();
@@ -143,8 +146,9 @@ public class SentryAppenderEventBuildingTest {
                 null, ndcEntries, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(SentryAppender.LOG4J_NDC, ndcEntries));
         }};
         assertNoErrorsInErrorHandler();
@@ -172,8 +176,9 @@ public class SentryAppenderEventBuildingTest {
                 null, null, locationInfo, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             StackTraceInterface stackTraceInterface = (StackTraceInterface) event.getSentryInterfaces()
                     .get(StackTraceInterface.STACKTRACE_INTERFACE);
             assertThat(stackTraceInterface.getStackTrace(), arrayWithSize(1));
@@ -205,8 +210,9 @@ public class SentryAppenderEventBuildingTest {
                 null, null, locationInfo, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getCulprit(), is("a.b(c:42)"));
         }};
         assertNoErrorsInErrorHandler();
@@ -223,8 +229,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new LoggingEvent(null, mockLogger, 0, Level.ERROR, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getCulprit(), is(loggerName));
         }};
         assertNoErrorsInErrorHandler();
@@ -239,8 +246,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new LoggingEvent(null, mockLogger, 0, Level.ERROR, null, null, null, null, null, properties));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getTags().entrySet(), hasSize(1));
             assertThat(event.getTags(), hasEntry(mockExtraTag, "ac84f38a-3889-41ed-9519-201402688abb"));
             assertThat(event.getExtra(), not(hasKey(mockExtraTag)));
@@ -260,8 +268,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new LoggingEvent(null, mockLogger, 0, Level.ERROR, null, null, null, null, null, properties));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getTags().entrySet(), hasSize(1));
             assertThat(event.getTags(), hasEntry(mockExtraTag, "3c8981b4-01ad-47ec-8a3a-77a0bbcb42e2"));
             assertThat(event.getExtra(), not(hasKey(mockExtraTag)));
@@ -277,8 +286,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new LoggingEvent(null, mockLogger, 0, Level.ERROR, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getRelease(), is(release));
         }};
         assertNoErrorsInErrorHandler();
@@ -292,8 +302,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new LoggingEvent(null, mockLogger, 0, Level.ERROR, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getEnvironment(), is(environment));
         }};
         assertNoErrorsInErrorHandler();

--- a/sentry-log4j/src/test/java/io/sentry/log4j/SentryAppenderFailuresTest.java
+++ b/sentry-log4j/src/test/java/io/sentry/log4j/SentryAppenderFailuresTest.java
@@ -1,6 +1,7 @@
 package io.sentry.log4j;
 
 import io.sentry.SentryClient;
+import io.sentry.event.EventBuilder;
 import mockit.*;
 import io.sentry.SentryClientFactory;
 import io.sentry.dsn.Dsn;
@@ -38,7 +39,7 @@ public class SentryAppenderFailuresTest {
     @Test
     public void testSentryFailureDoesNotPropagate() throws Exception {
         new NonStrictExpectations() {{
-            mockSentryClient.sendEvent((Event) any);
+            mockSentryClient.sendEvent((EventBuilder) any);
             result = new UnsupportedOperationException();
         }};
 
@@ -69,7 +70,7 @@ public class SentryAppenderFailuresTest {
             sentryAppender.append(new LoggingEvent(null, mockLogger, 0, Level.INFO, null, null));
 
             new Verifications() {{
-                mockSentryClient.sendEvent((Event) any);
+                mockSentryClient.sendEvent((EventBuilder) any);
                 times = 0;
             }};
             assertThat(mockUpErrorHandler.getErrorCount(), is(0));

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -301,8 +301,8 @@ public class SentryAppender extends AbstractAppender {
         SentryEnvironment.startManagingThread();
         try {
             lazyInit();
-            Event event = buildEvent(logEvent);
-            sentryClient.sendEvent(event);
+            EventBuilder eventBuilder = createEventBuilder(logEvent);
+            sentryClient.sendEvent(eventBuilder);
         } catch (Exception e) {
             error("An exception occurred while creating a new event in Sentry", logEvent, e);
         } finally {
@@ -328,12 +328,12 @@ public class SentryAppender extends AbstractAppender {
     }
 
     /**
-     * Builds an Event based on the logging event.
+     * Builds an EventBuilder based on the logging event.
      *
      * @param event Log generated.
-     * @return Event containing details provided by the logging system.
+     * @return EventBuilder containing details provided by the logging system.
      */
-    protected Event buildEvent(LogEvent event) {
+    protected EventBuilder createEventBuilder(LogEvent event) {
         Message eventMessage = event.getMessage();
         EventBuilder eventBuilder = new EventBuilder()
             .withSdkName(SentryEnvironment.SDK_NAME + ":log4j2")
@@ -405,8 +405,7 @@ public class SentryAppender extends AbstractAppender {
             eventBuilder.withTag(tagEntry.getKey(), tagEntry.getValue());
         }
 
-        sentryClient.runBuilderHelpers(eventBuilder);
-        return eventBuilder.build();
+        return eventBuilder;
     }
 
     public void setDsn(String dsn) {

--- a/sentry-log4j2/src/test/java/io/sentry/log4j2/SentryAppenderEventBuildingTest.java
+++ b/sentry-log4j2/src/test/java/io/sentry/log4j2/SentryAppenderEventBuildingTest.java
@@ -56,9 +56,9 @@ public class SentryAppenderEventBuildingTest {
                 null, null, null, threadName, null, date.getTime()));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getMessage(), is(message));
             assertThat(event.getLogger(), is(loggerName));
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(SentryAppender.THREAD_NAME, threadName));
@@ -84,8 +84,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new Log4jLogEvent(null, null, null, level, new SimpleMessage(""), null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getLevel(), is(expectedLevel));
         }};
         assertNoErrorsInErrorHandler();
@@ -98,8 +99,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new Log4jLogEvent(null, null, null, Level.ERROR, new SimpleMessage(""), exception));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             ExceptionInterface exceptionInterface = (ExceptionInterface) event.getSentryInterfaces()
                     .get(ExceptionInterface.EXCEPTION_INTERFACE);
             SentryException sentryException = exceptionInterface.getExceptions().getFirst();
@@ -119,9 +121,9 @@ public class SentryAppenderEventBuildingTest {
                 new FormattedMessage(messagePattern, parameters), null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
-
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             MessageInterface messageInterface = (MessageInterface) event.getSentryInterfaces()
                     .get(MessageInterface.MESSAGE_INTERFACE);
             assertThat(event.getMessage(), is("Formatted message first parameter [] null"));
@@ -140,8 +142,9 @@ public class SentryAppenderEventBuildingTest {
                 new SimpleMessage(""), null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getTags(), Matchers.<String, Object>hasEntry(SentryAppender.LOG4J_MARKER, markerName));
         }};
         assertNoErrorsInErrorHandler();
@@ -156,8 +159,9 @@ public class SentryAppenderEventBuildingTest {
                 Collections.singletonMap(extraKey, extraValue), null, null, null, 0));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(extraKey, extraValue));
         }};
         assertNoErrorsInErrorHandler();
@@ -175,8 +179,9 @@ public class SentryAppenderEventBuildingTest {
                 contextStack, null, null, 0));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat((List<String>) event.getExtra().get(SentryAppender.LOG4J_NDC), equalTo(contextStack.asList()));
         }};
         assertNoErrorsInErrorHandler();
@@ -191,8 +196,9 @@ public class SentryAppenderEventBuildingTest {
                 null, location, 0));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             StackTraceInterface stackTraceInterface = (StackTraceInterface) event.getSentryInterfaces()
                     .get(StackTraceInterface.STACKTRACE_INTERFACE);
             assertThat(stackTraceInterface.getStackTrace(), arrayWithSize(1));
@@ -209,8 +215,9 @@ public class SentryAppenderEventBuildingTest {
                 null, location, 0));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getCulprit(), is("a.b(c:42)"));
         }};
         assertNoErrorsInErrorHandler();
@@ -223,8 +230,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new Log4jLogEvent(loggerName, null, null, Level.INFO, new SimpleMessage(""), null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getCulprit(), is(loggerName));
         }};
         assertNoErrorsInErrorHandler();
@@ -239,8 +247,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new Log4jLogEvent(null, null, null, Level.INFO, new SimpleMessage(""), null, mdc, null, null, null, 0));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getTags().entrySet(), hasSize(1));
             assertThat(event.getTags(), hasEntry(mockExtraTag, "565940d2-f4a4-42f6-9496-42e3c7c85c43"));
             assertThat(event.getExtra(), not(hasKey(mockExtraTag)));
@@ -257,8 +266,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new Log4jLogEvent(null, null, null, Level.ERROR, new SimpleMessage(""), null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getRelease(), is(release));
         }};
         assertNoErrorsInErrorHandler();
@@ -272,8 +282,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new Log4jLogEvent(null, null, null, Level.ERROR, new SimpleMessage(""), null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getEnvironment(), is(environment));
         }};
         assertNoErrorsInErrorHandler();

--- a/sentry-log4j2/src/test/java/io/sentry/log4j2/SentryAppenderFailuresTest.java
+++ b/sentry-log4j2/src/test/java/io/sentry/log4j2/SentryAppenderFailuresTest.java
@@ -1,5 +1,6 @@
 package io.sentry.log4j2;
 
+import io.sentry.event.EventBuilder;
 import mockit.Injectable;
 import mockit.Mocked;
 import mockit.NonStrictExpectations;
@@ -37,7 +38,7 @@ public class SentryAppenderFailuresTest {
     @Test
     public void testSentryFailureDoesNotPropagate() throws Exception {
         new NonStrictExpectations() {{
-            mockSentryClient.sendEvent((Event) any);
+            mockSentryClient.sendEvent((EventBuilder) any);
             result = new UnsupportedOperationException();
         }};
 
@@ -68,7 +69,7 @@ public class SentryAppenderFailuresTest {
             sentryAppender.append(new Log4jLogEvent(null, null, null, Level.INFO, new SimpleMessage(""), null));
 
             new Verifications() {{
-                mockSentryClient.sendEvent((Event) any);
+                mockSentryClient.sendEvent((EventBuilder) any);
                 times = 0;
             }};
             assertThat(mockUpErrorHandler.getErrorCount(), is(0));

--- a/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderEventBuildingTest.java
+++ b/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderEventBuildingTest.java
@@ -70,9 +70,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(loggingEvent);
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getMessage(), is(message));
             assertThat(event.getLogger(), is(loggerName));
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(SentryAppender.THREAD_NAME, threadName));
@@ -97,8 +97,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new MockUpLoggingEvent(null, null, level, null, null, null).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getLevel(), is(expectedLevel));
         }};
         assertNoErrorsInStatusManager();
@@ -111,9 +112,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new MockUpLoggingEvent(null, null, Level.ERROR, null, null, exception).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             ExceptionInterface exceptionInterface = (ExceptionInterface) event.getSentryInterfaces()
                     .get(ExceptionInterface.EXCEPTION_INTERFACE);
             SentryException sentryException = exceptionInterface.getExceptions().getFirst();
@@ -133,9 +134,9 @@ public class SentryAppenderEventBuildingTest {
                 .getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             MessageInterface messageInterface = (MessageInterface) event.getSentryInterfaces()
                     .get(MessageInterface.MESSAGE_INTERFACE);
 
@@ -156,9 +157,9 @@ public class SentryAppenderEventBuildingTest {
                         .getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getTags(), Matchers.<String, Object>hasEntry(SentryAppender.LOGBACK_MARKER, markerName));
         }};
         assertNoErrorsInStatusManager();
@@ -173,9 +174,9 @@ public class SentryAppenderEventBuildingTest {
                 Collections.singletonMap(extraKey, extraValue), null, null, 0).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(extraKey, extraValue));
         }};
         assertNoErrorsInStatusManager();
@@ -190,9 +191,9 @@ public class SentryAppenderEventBuildingTest {
                 null, null, null, 0, Collections.singletonMap(extraKey, extraValue)).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(extraKey, extraValue));
         }};
         assertNoErrorsInStatusManager();
@@ -210,9 +211,9 @@ public class SentryAppenderEventBuildingTest {
                 Collections.singletonMap(contextKey, contextValue)).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(mdcKey, mdcValue));
         }};
         assertNoErrorsInStatusManager();
@@ -228,9 +229,9 @@ public class SentryAppenderEventBuildingTest {
                 .getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             StackTraceInterface stackTraceInterface = (StackTraceInterface) event.getSentryInterfaces()
                     .get(StackTraceInterface.STACKTRACE_INTERFACE);
             assertThat(stackTraceInterface.getStackTrace(), is(SentryStackTraceElement.fromStackTraceElements(location)));
@@ -247,9 +248,9 @@ public class SentryAppenderEventBuildingTest {
                 .getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getCulprit(), is("a.b(c:42)"));
         }};
         assertNoErrorsInStatusManager();
@@ -262,9 +263,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new MockUpLoggingEvent(loggerName, null, Level.INFO, null, null, null).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getCulprit(), is(loggerName));
         }};
         assertNoErrorsInStatusManager();
@@ -280,8 +281,9 @@ public class SentryAppenderEventBuildingTest {
                 null, 0).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getTags().entrySet(), hasSize(1));
             assertThat(event.getTags(), hasEntry(mockExtraTag, "47008f35-50c8-4e40-94ca-c8c1a3ddb729"));
             assertThat(event.getExtra(), not(hasKey(mockExtraTag)));
@@ -298,8 +300,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new MockUpLoggingEvent(null, null, Level.INFO, null, null, null).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getRelease(), is(release));
         }};
         assertNoErrorsInStatusManager();
@@ -313,8 +316,9 @@ public class SentryAppenderEventBuildingTest {
         sentryAppender.append(new MockUpLoggingEvent(null, null, Level.INFO, null, null, null).getMockInstance());
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getEnvironment(), is(environment));
         }};
         assertNoErrorsInStatusManager();

--- a/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderEventLevelFilterTest.java
+++ b/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderEventLevelFilterTest.java
@@ -2,6 +2,7 @@ package io.sentry.logback;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.core.Context;
+import io.sentry.event.EventBuilder;
 import mockit.Injectable;
 import mockit.Tested;
 import mockit.Verifications;
@@ -53,7 +54,7 @@ public class SentryAppenderEventLevelFilterTest {
         sentryAppender.append(new MockUpLoggingEvent(null, null, Level.ERROR, null, null, null).getMockInstance());
 
         new Verifications() {{
-            mockSentryClient.sendEvent((Event) any);
+            mockSentryClient.sendEvent((EventBuilder) any);
             minTimes = expectedEvents;
             maxTimes = expectedEvents;
         }};
@@ -68,7 +69,7 @@ public class SentryAppenderEventLevelFilterTest {
         sentryAppender.append(new MockUpLoggingEvent(null, null, Level.ERROR, null, null, null).getMockInstance());
 
         new Verifications() {{
-            mockSentryClient.sendEvent((Event) any);
+            mockSentryClient.sendEvent((EventBuilder) any);
             minTimes = 5;
             maxTimes = 5;
         }};

--- a/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderFailuresTest.java
+++ b/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderFailuresTest.java
@@ -5,6 +5,7 @@ import ch.qos.logback.core.BasicStatusManager;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.status.OnConsoleStatusListener;
 import io.sentry.SentryClient;
+import io.sentry.event.EventBuilder;
 import mockit.*;
 import io.sentry.SentryClientFactory;
 import io.sentry.dsn.Dsn;
@@ -45,7 +46,7 @@ public class SentryAppenderFailuresTest {
         sentryAppender.setContext(mockContext);
         sentryAppender.setMinLevel("ALL");
         new NonStrictExpectations() {{
-            mockSentryClient.sendEvent((Event) any);
+            mockSentryClient.sendEvent((EventBuilder) any);
             result = new UnsupportedOperationException();
         }};
         sentryAppender.start();
@@ -53,7 +54,7 @@ public class SentryAppenderFailuresTest {
         sentryAppender.append(new MockUpLoggingEvent(null, null, Level.INFO, null, null, null).getMockInstance());
 
         new Verifications() {{
-            mockSentryClient.sendEvent((Event) any);
+            mockSentryClient.sendEvent((EventBuilder) any);
         }};
         assertThat(mockContext.getStatusManager().getCount(), is(1));
     }
@@ -86,7 +87,7 @@ public class SentryAppenderFailuresTest {
             sentryAppender.append(new MockUpLoggingEvent(null, null, Level.INFO, null, null, null).getMockInstance());
 
             new Verifications() {{
-                mockSentryClient.sendEvent((Event) any);
+                mockSentryClient.sendEvent((EventBuilder) any);
                 times = 0;
             }};
             assertThat(mockContext.getStatusManager().getCount(), is(0));

--- a/sentry/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry/src/main/java/io/sentry/jul/SentryHandler.java
@@ -126,7 +126,6 @@ public class SentryHandler extends Handler {
         if (!initialized) {
             synchronized (this) {
                 if (!initialized) {
-
                     try {
                         String sentryClientFactory = Lookup.lookup("factory");
                         if (sentryClientFactory != null) {
@@ -261,8 +260,8 @@ public class SentryHandler extends Handler {
         SentryEnvironment.startManagingThread();
         try {
             lazyInit();
-            Event event = buildEvent(record);
-            sentryClient.sendEvent(event);
+            EventBuilder eventBuilder = createEventBuilder(record);
+            sentryClient.sendEvent(eventBuilder);
         } catch (Exception e) {
             reportError("An exception occurred while creating a new event in Sentry", e, ErrorManager.WRITE_FAILURE);
         } finally {
@@ -290,12 +289,12 @@ public class SentryHandler extends Handler {
     }
 
     /**
-     * Builds an Event based on the log record.
+     * Builds an EventBuilder based on the log record.
      *
      * @param record Log generated.
-     * @return Event containing details provided by the logging system.
+     * @return EventBuilder containing details provided by the logging system.
      */
-    protected Event buildEvent(LogRecord record) {
+    protected EventBuilder createEventBuilder(LogRecord record) {
         EventBuilder eventBuilder = new EventBuilder()
             .withSdkName(SentryEnvironment.SDK_NAME + ":jul")
             .withLevel(getLevel(record.getLevel()))
@@ -370,8 +369,7 @@ public class SentryHandler extends Handler {
             eventBuilder.withServerName(serverName.trim());
         }
 
-        sentryClient.runBuilderHelpers(eventBuilder);
-        return eventBuilder.build();
+        return eventBuilder;
     }
 
     /**

--- a/sentry/src/test/java/io/sentry/jul/SentryHandlerEventBuildingTest.java
+++ b/sentry/src/test/java/io/sentry/jul/SentryHandlerEventBuildingTest.java
@@ -48,9 +48,9 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
         sentryHandler.publish(newLogRecord(loggerName, Level.INFO, message, arguments, null, null, threadId, date.getTime()));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.runBuilderHelpers((EventBuilder) any);
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getMessage(), is(message));
             Map<String, SentryInterface> sentryInterfaces = event.getSentryInterfaces();
             assertThat(sentryInterfaces, hasKey(MessageInterface.MESSAGE_INTERFACE));
@@ -81,8 +81,9 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
         sentryHandler.publish(newLogRecord(null, level, null, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getLevel(), is(expectedLevel));
         }};
         assertNoErrorsInErrorManager();
@@ -95,8 +96,9 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
         sentryHandler.publish(newLogRecord(null, Level.SEVERE, null, null, exception));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             ExceptionInterface exceptionInterface = (ExceptionInterface) event.getSentryInterfaces()
                     .get(ExceptionInterface.EXCEPTION_INTERFACE);
             final SentryException sentryException = exceptionInterface.getExceptions().getFirst();
@@ -117,8 +119,9 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
                 new StackTraceElement[]{stackTraceElement}, 0, 0));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getCulprit(), is("a.b"));
         }};
         assertNoErrorsInErrorManager();
@@ -131,8 +134,9 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
         sentryHandler.publish(newLogRecord(loggerName, Level.SEVERE, null, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getCulprit(), is(loggerName));
         }};
         assertNoErrorsInErrorManager();
@@ -167,8 +171,9 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
         sentryHandler.publish(newLogRecord(null, Level.INFO, null, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getRelease(), is(release));
         }};
         assertNoErrorsInErrorManager();
@@ -182,8 +187,9 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
         sentryHandler.publish(newLogRecord(null, Level.INFO, null, null, null));
 
         new Verifications() {{
-            Event event;
-            mockSentryClient.sendEvent(event = withCapture());
+            EventBuilder eventBuilder;
+            mockSentryClient.sendEvent(eventBuilder = withCapture());
+            Event event = eventBuilder.build();
             assertThat(event.getEnvironment(), is(environment));
         }};
         assertNoErrorsInErrorManager();


### PR DESCRIPTION
…ying the build codepath.

Pulled out from a closed PR, this is just a cleanup so that the event building code path (such as ensuring `runBuilderHelpers` is called) only exists in one place.

Aside: I think in general we should recommend users only use `EventBuilder`s because otherwise it confuses them when their helpers aren't run (for example, if they call `Sentry.capture(myBuilder.build());`
