### PR TITLE
android: kernel_version: fix for pre-M and align to AOSP Settings.

### DIFF
--- a/raven-android/src/main/java/com/getsentry/raven/android/Util.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/Util.java
@@ -5,6 +5,10 @@ import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
 /**
  * Raven Android utility methods.
  */
@@ -58,6 +62,21 @@ public final class Util {
         }
 
         return isConnected(ctx);
+    }
+
+    /**
+     * Reads a line from the specified file.
+     * @param filename the file to read from
+     * @return the first line, if any.
+     * @throws IOException if the file couldn't be read
+     */
+    public static String readLine(String filename) throws IOException {
+        BufferedReader reader = new BufferedReader(new FileReader(filename), 256);
+        try {
+            return reader.readLine();
+        } finally {
+            reader.close();
+        }
     }
 
 }

--- a/raven-android/src/main/java/com/getsentry/raven/android/Util.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/Util.java
@@ -71,7 +71,7 @@ public final class Util {
      * @throws IOException if the file couldn't be read
      */
     public static String readLine(String filename) throws IOException {
-        BufferedReader reader = new BufferedReader(new FileReader(filename), 256);
+        BufferedReader reader = new BufferedReader(new FileReader(filename));
         try {
             return reader.readLine();
         } finally {

--- a/raven-android/src/main/java/com/getsentry/raven/android/Util.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/Util.java
@@ -5,10 +5,6 @@ import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-
 /**
  * Raven Android utility methods.
  */
@@ -62,21 +58,6 @@ public final class Util {
         }
 
         return isConnected(ctx);
-    }
-
-    /**
-     * Reads a line from the specified file.
-     * @param filename the file to read from
-     * @return the first line, if any.
-     * @throws IOException if the file couldn't be read
-     */
-    public static String readLine(String filename) throws IOException {
-        BufferedReader reader = new BufferedReader(new FileReader(filename));
-        try {
-            return reader.readLine();
-        } finally {
-            reader.close();
-        }
     }
 
 }

--- a/raven-android/src/main/java/com/getsentry/raven/android/event/helper/AndroidEventBuilderHelper.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/event/helper/AndroidEventBuilderHelper.java
@@ -305,7 +305,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
         //     (gcc version 4.6.x-xxx 20120106 (prerelease) (GCC) ) #1 SMP PREEMPT \
         //     Thu Jun 28 11:02:39 PDT 2012
 
-        String PROC_VERSION_REGEX =
+        final String procVersionRegex =
                 "Linux version (\\S+) " + /* group 1: "3.0.31-g6fb96c9" */
                 "\\((\\S+?)\\) " +        /* group 2: "x@y.com" (kernel builder) */
                 "(?:\\(gcc.+? \\)) " +    /* ignore: GCC version information */
@@ -313,24 +313,26 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
                 "(?:.*?)?" +              /* ignore: optional SMP, PREEMPT, and any CONFIG_FLAGS */
                 "((Sun|Mon|Tue|Wed|Thu|Fri|Sat).+)"; /* group 4: "Thu Jun 28 11:02:39 PDT 2012" */
 
-        int PROC_VERSION_GROUP_1 = 1;
-        int PROC_VERSION_GROUP_2 = 2;
-        int PROC_VERSION_GROUP_3 = 3;
-        int PROC_VERSION_GROUP_4 = 4;
-        int PROC_VERSION_GROUP_COUNT = PROC_VERSION_GROUP_4;
+        // CHECKSTYLE.OFF: MagicNumber
+        final int procVersionGroupKernelVersion = 1;
+        final int procVersionGroupBuilderName = 2;
+        final int procVersionGroupBuildNumber = 3;
+        final int procVersionGroupBuildDate = 4;
+        final int procVersionGroupCount = 4;
+        // CHECKSTYLE.ON: MagicNumber
 
-        Matcher m = Pattern.compile(PROC_VERSION_REGEX).matcher(rawKernelVersion);
+        Matcher m = Pattern.compile(procVersionRegex).matcher(rawKernelVersion);
         if (!m.matches()) {
             Log.e(TAG, "Regex did not match on /proc/version: " + rawKernelVersion);
             return "Unavailable";
-        } else if (m.groupCount() < PROC_VERSION_GROUP_COUNT) {
+        } else if (m.groupCount() < procVersionGroupCount) {
             Log.e(TAG, "Regex match on /proc/version only returned " + m.groupCount()
                     + " groups");
             return "Unavailable";
         }
-        return m.group(PROC_VERSION_GROUP_1) + "\n" + // 3.0.31-g6fb96c9
-                m.group(PROC_VERSION_GROUP_2) + " " + m.group(PROC_VERSION_GROUP_3) + "\n" + // x@y.com #1
-                m.group(PROC_VERSION_GROUP_2); // Thu Jun 28 11:02:39 PDT 2012
+        return m.group(procVersionGroupKernelVersion) + "\n" + // 3.0.31-g6fb96c9
+                m.group(procVersionGroupBuilderName) + " " + m.group(procVersionGroupBuildNumber) + "\n" + // x@y.com #1
+                m.group(procVersionGroupBuildDate); // Thu Jun 28 11:02:39 PDT 2012
     }
 
     /**

--- a/raven-android/src/main/java/com/getsentry/raven/android/event/helper/AndroidEventBuilderHelper.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/event/helper/AndroidEventBuilderHelper.java
@@ -20,10 +20,7 @@ import com.getsentry.raven.event.EventBuilder;
 import com.getsentry.raven.event.helper.EventBuilderHelper;
 import com.getsentry.raven.event.interfaces.UserInterface;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -308,7 +305,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
         //     (gcc version 4.6.x-xxx 20120106 (prerelease) (GCC) ) #1 SMP PREEMPT \
         //     Thu Jun 28 11:02:39 PDT 2012
 
-        final String PROC_VERSION_REGEX =
+        String PROC_VERSION_REGEX =
                 "Linux version (\\S+) " + /* group 1: "3.0.31-g6fb96c9" */
                 "\\((\\S+?)\\) " +        /* group 2: "x@y.com" (kernel builder) */
                 "(?:\\(gcc.+? \\)) " +    /* ignore: GCC version information */
@@ -316,18 +313,24 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
                 "(?:.*?)?" +              /* ignore: optional SMP, PREEMPT, and any CONFIG_FLAGS */
                 "((Sun|Mon|Tue|Wed|Thu|Fri|Sat).+)"; /* group 4: "Thu Jun 28 11:02:39 PDT 2012" */
 
+        int PROC_VERSION_GROUP_1 = 1;
+        int PROC_VERSION_GROUP_2 = 2;
+        int PROC_VERSION_GROUP_3 = 3;
+        int PROC_VERSION_GROUP_4 = 4;
+        int PROC_VERSION_GROUP_COUNT = PROC_VERSION_GROUP_4;
+
         Matcher m = Pattern.compile(PROC_VERSION_REGEX).matcher(rawKernelVersion);
         if (!m.matches()) {
             Log.e(TAG, "Regex did not match on /proc/version: " + rawKernelVersion);
             return "Unavailable";
-        } else if (m.groupCount() < 4) {
+        } else if (m.groupCount() < PROC_VERSION_GROUP_COUNT) {
             Log.e(TAG, "Regex match on /proc/version only returned " + m.groupCount()
                     + " groups");
             return "Unavailable";
         }
-        return m.group(1) + "\n" +                 // 3.0.31-g6fb96c9
-                m.group(2) + " " + m.group(3) + "\n" + // x@y.com #1
-                m.group(4);                            // Thu Jun 28 11:02:39 PDT 2012
+        return m.group(PROC_VERSION_GROUP_1) + "\n" + // 3.0.31-g6fb96c9
+                m.group(PROC_VERSION_GROUP_2) + " " + m.group(PROC_VERSION_GROUP_3) + "\n" + // x@y.com #1
+                m.group(PROC_VERSION_GROUP_2); // Thu Jun 28 11:02:39 PDT 2012
     }
 
     /**

--- a/raven-android/src/main/java/com/getsentry/raven/android/event/helper/AndroidEventBuilderHelper.java
+++ b/raven-android/src/main/java/com/getsentry/raven/android/event/helper/AndroidEventBuilderHelper.java
@@ -28,6 +28,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static android.content.Context.ACTIVITY_SERVICE;
 
@@ -291,27 +293,41 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
      * @return the device's current kernel version, as a string (from uname -a)
      */
     private static String getKernelVersion() {
-        String errorMsg = "Exception while attempting to read kernel information";
-        BufferedReader br = null;
         try {
-            Process p = Runtime.getRuntime().exec("uname -a");
-            if (p.waitFor() == 0) {
-                br = new BufferedReader(new InputStreamReader(p.getInputStream()));
-                return br.readLine();
-            }
+            return formatKernelVersion(Util.readLine("/proc/version"));
         } catch (Exception e) {
-            Log.e(TAG, errorMsg, e);
-        } finally {
-            if (br != null) {
-                try {
-                    br.close();
-                } catch (IOException ioe) {
-                    Log.e(TAG, errorMsg, ioe);
-                }
-            }
+            Log.e(TAG, "Exception while attempting to read kernel information", e);
         }
 
         return null;
+    }
+
+    private static String formatKernelVersion(String rawKernelVersion) {
+        // Example (see tests for more):
+        // Linux version 3.0.31-g6fb96c9 (android-build@xxx.xxx.xxx.xxx.com) \
+        //     (gcc version 4.6.x-xxx 20120106 (prerelease) (GCC) ) #1 SMP PREEMPT \
+        //     Thu Jun 28 11:02:39 PDT 2012
+
+        final String PROC_VERSION_REGEX =
+                "Linux version (\\S+) " + /* group 1: "3.0.31-g6fb96c9" */
+                "\\((\\S+?)\\) " +        /* group 2: "x@y.com" (kernel builder) */
+                "(?:\\(gcc.+? \\)) " +    /* ignore: GCC version information */
+                "(#\\d+) " +              /* group 3: "#1" */
+                "(?:.*?)?" +              /* ignore: optional SMP, PREEMPT, and any CONFIG_FLAGS */
+                "((Sun|Mon|Tue|Wed|Thu|Fri|Sat).+)"; /* group 4: "Thu Jun 28 11:02:39 PDT 2012" */
+
+        Matcher m = Pattern.compile(PROC_VERSION_REGEX).matcher(rawKernelVersion);
+        if (!m.matches()) {
+            Log.e(TAG, "Regex did not match on /proc/version: " + rawKernelVersion);
+            return "Unavailable";
+        } else if (m.groupCount() < 4) {
+            Log.e(TAG, "Regex match on /proc/version only returned " + m.groupCount()
+                    + " groups");
+            return "Unavailable";
+        }
+        return m.group(1) + "\n" +                 // 3.0.31-g6fb96c9
+                m.group(2) + " " + m.group(3) + "\n" + // x@y.com #1
+                m.group(4);                            // Thu Jun 28 11:02:39 PDT 2012
     }
 
     /**


### PR DESCRIPTION
On Android versions previous to M (Marshmallow), `uname` command is not
available, leading to an exception while computing `kernel_version` :
```
 E/com.getsentry.raven.android.event.helper.AndroidEventBuilderHelper: Exception while attempting to read kernel information
   java.io.IOException: Error running exec(). Command: [uname, -a] Working Directory: null Environment: null
       at java.lang.ProcessManager.exec(ProcessManager.java:211)
       at java.lang.Runtime.exec(Runtime.java:173)
       at java.lang.Runtime.exec(Runtime.java:246)
       at java.lang.Runtime.exec(Runtime.java:189)
       at com.getsentry.raven.android.event.helper.AndroidEventBuilderHelper.getKernelVersion(AndroidEventBuilderHelper.java:267)
       at com.getsentry.raven.android.event.helper.AndroidEventBuilderHelper.<clinit>(AndroidEventBuilderHelper.java:41)
       at com.getsentry.raven.android.AndroidRavenFactory.createRavenInstance(AndroidRavenFactory.java:44)
       at com.getsentry.raven.RavenFactory.ravenInstance(RavenFactory.java:103)
       at com.getsentry.raven.RavenFactory.ravenInstance(RavenFactory.java:73)
       at com.getsentry.raven.android.Raven.init(Raven.java:140)
       at com.getsentry.raven.android.Raven.init(Raven.java:90)
       at com.getsentry.raven.android.Raven.init(Raven.java:69)
       at com.getsentry.raven.android.Raven.init(Raven.java:41)
```

The proposed solution is to use the kernel version string used by AOSP
in Settings application as it relies on `/proc/version` file which is
world readable.

This will change the format of `kernel_version` from something like : 
```
Linux localhost 3.10.0+ #393 PREEMPT Thu Feb 4 11:32:54 PST 2016 x86_64
```
to : 
```
3.10.0+
jinqian@jinqian.mtv.corp.google.com #393
Thu Feb 4 11:32:54 PST 2016
```
References:
* this code : https://android.googlesource.com/platform/packages/apps/Settings/+/marshmallow-release/src/com/android/settings/DeviceInfoSettings.java#379 
* no `uname` before M : https://android.googlesource.com/platform/system/core/+/lollipop-mr1-release/toolbox/Android.mk