### PR TITLE
Unify SentryClient creation code, remove the need for factory registr…

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -424,8 +424,8 @@ Custom SentryClientFactory
 
 At times, you may require custom functionality that is not included in ``sentry-java``
 already. The most common way to do this is to create your own ``SentryClientFactory`` instance
-as seen in the example below. Note that you'll also need to register it with Sentry and
-possibly configure your integration to use it, as shown below.
+as seen in the example below. See the documentation for the integration you use to find out how to
+configure it to use your custom ``SentryClientFactory``.
 
 Implementation
 ~~~~~~~~~~~~~~
@@ -433,7 +433,6 @@ Implementation
 .. sourcecode:: java
 
     public class MySentryClientFactory extends DefaultSentryClientFactory {
-
         @Override
         public SentryClient createSentryClient(Dsn dsn) {
             SentryClient sentry = new SentryClient(createConnection(dsn));
@@ -447,42 +446,5 @@ Implementation
 
             return sentry;
         }
-
     }
 
-Next, you'll need to register your class with Sentry in one of two ways.
-
-Registration
-~~~~~~~~~~~~
-
-Java ServiceLoader Provider (Recommended)
-`````````````````````````````````````````
-
-You'll need to add a ``ServiceLoader`` provider file to your project at
-``src/main/resources/META-INF/services/io.sentry.SentryClientFactory`` that contains
-the name of your class so that it will be considered as a candidate ``SentryClientFactory``. For an example, see
-`how we configure the DefaultSentryClientFactory itself
-<https://github.com/getsentry/sentry-java/blob/master/sentry/src/main/resources/META-INF/services/io.sentry.SentryClientFactory>`_.
-
-Manual Registration
-```````````````````
-
-You can also manually register your ``SentryClientFactory`` instance. If you are using
-an integration that builds its own Sentry client, such as a logging integration, this should
-be done early in your application lifecycle so that your factory is available the first time
-you attempt to send an event to the Sentry server.
-
-.. sourcecode:: java
-
-    class MyApp {
-        public static void main(String[] args) {
-            SentryClientFactory.registerFactory(new MySentryClientFactory());
-            // ... your app code ...
-        }
-    }
-
-Configuration
-~~~~~~~~~~~~~
-
-Finally, see the documentation for the integration you use to find out how to
-configure it to use your custom ``SentryClientFactory``.

--- a/sentry-appengine/src/main/resources/META-INF/services/io.sentry.SentryClientFactory
+++ b/sentry-appengine/src/main/resources/META-INF/services/io.sentry.SentryClientFactory
@@ -1,1 +1,0 @@
-io.sentry.appengine.AppEngineSentryClientFactory

--- a/sentry-appengine/src/test/java/io/sentry/appengine/AppEngineSentryClientFactoryTest.java
+++ b/sentry-appengine/src/test/java/io/sentry/appengine/AppEngineSentryClientFactoryTest.java
@@ -1,15 +1,12 @@
 package io.sentry.appengine;
 
 import mockit.*;
-import io.sentry.SentryClientFactory;
 import io.sentry.appengine.connection.AppEngineAsyncConnection;
 import io.sentry.connection.Connection;
 import io.sentry.dsn.Dsn;
-import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
-import java.util.ServiceLoader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -22,13 +19,6 @@ public class AppEngineSentryClientFactoryTest {
     private Connection mockConnection;
     @Injectable
     private Dsn mockDsn;
-
-    @Test
-    public void checkServiceLoaderProvidesFactory() throws Exception {
-        ServiceLoader<SentryClientFactory> sentryFactories = ServiceLoader.load(SentryClientFactory.class);
-
-        assertThat(sentryFactories, Matchers.<SentryClientFactory>hasItem(instanceOf(AppEngineSentryClientFactory.class)));
-    }
 
     @Test
     public void asyncConnectionCreatedByAppEngineSentryClientFactoryIsForAppEngine() throws Exception {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -5,7 +5,6 @@ import io.sentry.event.Breadcrumb;
 import io.sentry.event.Event;
 import io.sentry.event.EventBuilder;
 import io.sentry.event.User;
-import io.sentry.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,22 +77,7 @@ public final class Sentry {
      * @return SentryClient
      */
     public static SentryClient init(String dsn, SentryClientFactory sentryClientFactory) {
-        SentryClient sentryClient;
-        if (sentryClientFactory != null) {
-            Dsn realDsn;
-            if (!Util.isNullOrEmpty(dsn)) {
-                realDsn = new Dsn(dsn);
-            } else {
-                realDsn = new Dsn(Dsn.dsnLookup());
-            }
-
-            // use the factory instance directly
-            sentryClient = sentryClientFactory.createSentryClient(realDsn);
-        } else {
-            // do static factory lookup
-            sentryClient = SentryClientFactory.sentryClient(dsn);
-        }
-
+        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn, sentryClientFactory);
         setStoredClient(sentryClient);
         return sentryClient;
     }

--- a/sentry/src/main/resources/META-INF/services/io.sentry.SentryClientFactory
+++ b/sentry/src/main/resources/META-INF/services/io.sentry.SentryClientFactory
@@ -1,1 +1,0 @@
-io.sentry.DefaultSentryClientFactory

--- a/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
@@ -11,13 +11,6 @@ import static org.hamcrest.Matchers.is;
 
 public class DefaultSentryClientFactoryTest extends BaseTest {
     @Test
-    public void checkServiceLoaderProvidesFactory() throws Exception {
-        ServiceLoader<SentryClientFactory> sentryFactories = ServiceLoader.load(SentryClientFactory.class);
-
-        assertThat(sentryFactories, contains(instanceOf(DefaultSentryClientFactory.class)));
-    }
-
-    @Test
     public void testFieldsFromDsn() throws Exception {
         String release = "rel";
         String dist = "dis";

--- a/sentry/src/test/java/io/sentry/TestFactory.java
+++ b/sentry/src/test/java/io/sentry/TestFactory.java
@@ -1,0 +1,11 @@
+package io.sentry;
+
+import io.sentry.dsn.Dsn;
+
+public class TestFactory extends DefaultSentryClientFactory {
+    @Override
+    protected SentryClient configureSentryClient(SentryClient sentryClient, Dsn dsn) {
+        sentryClient.setRelease("312407214120");
+        return super.configureSentryClient(sentryClient, dsn);
+    }
+}


### PR DESCRIPTION
…ation.

This greatly simplifies `SentryClient` init code. Also drops all the factory registration stuff, which IMO was a misuse of the `ServiceLoader` API. `ServiceLoader`s are useful for extending an API that needs to iterate over multiple implementations and try each one. But `SentryClientFactory`s are well known in advance and one and only one should be used. Requiring the user to register it at all is needless. Now they can make a class, and set `SENTRY_FACTORY=com.example.Foo` and they're done. If it doesn't exist or fails to initialize an error will be logged. If no factory is specified then of course `DefaultSentryClientFactory` is used.