### PR TITLE
Add 'integrations' array field to 'sdk' in JSON.

### DIFF
--- a/sentry-android/src/main/java/io/sentry/android/event/helper/AndroidEventBuilderHelper.java
+++ b/sentry-android/src/main/java/io/sentry/android/event/helper/AndroidEventBuilderHelper.java
@@ -16,7 +16,6 @@ import android.os.StatFs;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
 import android.util.Log;
-import io.sentry.environment.SentryEnvironment;
 import io.sentry.event.EventBuilder;
 import io.sentry.event.helper.EventBuilderHelper;
 import io.sentry.event.interfaces.UserInterface;
@@ -58,7 +57,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
 
     @Override
     public void helpBuildingEvent(EventBuilder eventBuilder) {
-        eventBuilder.withSdkName(SentryEnvironment.SDK_NAME + ":android");
+        eventBuilder.withSdkIntegration("android");
         PackageInfo packageInfo = getPackageInfo(ctx);
         if (packageInfo != null) {
             eventBuilder.withRelease(packageInfo.packageName + "-" + packageInfo.versionName);

--- a/sentry-log4j/src/main/java/io/sentry/log4j/SentryAppender.java
+++ b/sentry-log4j/src/main/java/io/sentry/log4j/SentryAppender.java
@@ -99,7 +99,7 @@ public class SentryAppender extends AppenderSkeleton {
      */
     protected EventBuilder createEventBuilder(LoggingEvent loggingEvent) {
         EventBuilder eventBuilder = new EventBuilder()
-            .withSdkName(SentryEnvironment.SDK_NAME + ":log4j")
+            .withSdkIntegration("log4j")
             .withTimestamp(new Date(loggingEvent.getTimeStamp()))
             .withMessage(loggingEvent.getRenderedMessage())
             .withLogger(loggingEvent.getLoggerName())

--- a/sentry-log4j/src/test/java/io/sentry/log4j/SentryAppenderEventBuildingTest.java
+++ b/sentry-log4j/src/test/java/io/sentry/log4j/SentryAppenderEventBuildingTest.java
@@ -74,7 +74,7 @@ public class SentryAppenderEventBuildingTest extends BaseTest {
             assertThat(event.getLogger(), is(loggerName));
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(SentryAppender.THREAD_NAME, threadName));
             assertThat(event.getTimestamp(), is(date));
-            assertThat(event.getSdkName(), is(SentryEnvironment.SDK_NAME + ":log4j"));
+            assertThat(event.getSdk().getIntegrations(), contains("log4j"));
         }};
         assertNoErrorsInErrorHandler();
     }

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -147,7 +147,7 @@ public class SentryAppender extends AbstractAppender {
     protected EventBuilder createEventBuilder(LogEvent event) {
         Message eventMessage = event.getMessage();
         EventBuilder eventBuilder = new EventBuilder()
-            .withSdkName(SentryEnvironment.SDK_NAME + ":log4j2")
+            .withSdkIntegration("log4j2")
             .withTimestamp(new Date(event.getTimeMillis()))
             .withMessage(eventMessage.getFormattedMessage())
             .withLogger(event.getLoggerName())

--- a/sentry-log4j2/src/test/java/io/sentry/log4j2/SentryAppenderEventBuildingTest.java
+++ b/sentry-log4j2/src/test/java/io/sentry/log4j2/SentryAppenderEventBuildingTest.java
@@ -69,7 +69,7 @@ public class SentryAppenderEventBuildingTest extends BaseTest {
             assertThat(event.getLogger(), is(loggerName));
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(SentryAppender.THREAD_NAME, threadName));
             assertThat(event.getTimestamp(), is(date));
-            assertThat(event.getSdkName(), is(SentryEnvironment.SDK_NAME + ":log4j2"));
+            assertThat(event.getSdk().getIntegrations(), contains("log4j2"));
         }};
         assertNoErrorsInErrorHandler();
     }

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -122,7 +122,7 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      */
     protected EventBuilder createEventBuilder(ILoggingEvent iLoggingEvent) {
         EventBuilder eventBuilder = new EventBuilder()
-            .withSdkName(SentryEnvironment.SDK_NAME + ":logback")
+            .withSdkIntegration("logback")
             .withTimestamp(new Date(iLoggingEvent.getTimeStamp()))
             .withMessage(iLoggingEvent.getFormattedMessage())
             .withLogger(iLoggingEvent.getLoggerName())

--- a/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderEventBuildingTest.java
+++ b/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderEventBuildingTest.java
@@ -82,7 +82,7 @@ public class SentryAppenderEventBuildingTest extends BaseTest {
             assertThat(event.getLogger(), is(loggerName));
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(SentryAppender.THREAD_NAME, threadName));
             assertThat(event.getTimestamp(), is(date));
-            assertThat(event.getSdkName(), is(SentryEnvironment.SDK_NAME + ":logback"));
+            assertThat(event.getSdk().getIntegrations(), contains("logback"));
         }};
         assertNoErrorsInStatusManager();
     }

--- a/sentry/src/main/java/io/sentry/event/Event.java
+++ b/sentry/src/main/java/io/sentry/event/Event.java
@@ -55,13 +55,10 @@ public class Event implements Serializable {
      */
     private String platform;
     /**
-     * A string representing the name of the SDK used to create the event.
+     * An {@link Sdk} instance representing the version and integrations used to send
+     * the event.
      */
-    private String sdkName;
-    /**
-     * A string representing the version of the SDK used to create the event.
-     */
-    private String sdkVersion;
+    private Sdk sdk;
     /**
      * Function call which was the primary perpetrator of this event.
      */
@@ -177,20 +174,12 @@ public class Event implements Serializable {
         this.platform = platform;
     }
 
-    public String getSdkName() {
-        return sdkName;
+    public Sdk getSdk() {
+        return sdk;
     }
 
-    public void setSdkName(String sdkName) {
-        this.sdkName = sdkName;
-    }
-
-    public String getSdkVersion() {
-        return sdkVersion;
-    }
-
-    public void setSdkVersion(String sdkVersion) {
-        this.sdkVersion = sdkVersion;
+    public void setSdk(Sdk sdk) {
+        this.sdk = sdk;
     }
 
     public String getCulprit() {

--- a/sentry/src/main/java/io/sentry/event/Sdk.java
+++ b/sentry/src/main/java/io/sentry/event/Sdk.java
@@ -1,0 +1,47 @@
+package io.sentry.event;
+
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * Represents the current SDK and any integrations used to create an {@link Event}.
+ */
+public class Sdk implements Serializable {
+    /**
+     * Name of the SDK.
+     */
+    private String name;
+    /**
+     * Version of the SDK.
+     */
+    private String version;
+    /**
+     * Set of integrations used.
+     */
+    private Set<String> integrations;
+
+    /**
+     * Build an {@link Sdk} instance.
+     *
+     * @param name Name of the SDK.
+     * @param version Version of the SDK.
+     * @param integrations Set of integrations used.
+     */
+    public Sdk(String name, String version, Set<String> integrations) {
+        this.name = name;
+        this.version = version;
+        this.integrations = integrations;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Set<String> getIntegrations() {
+        return integrations;
+    }
+}

--- a/sentry/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry/src/main/java/io/sentry/jul/SentryHandler.java
@@ -109,7 +109,7 @@ public class SentryHandler extends Handler {
      */
     protected EventBuilder createEventBuilder(LogRecord record) {
         EventBuilder eventBuilder = new EventBuilder()
-            .withSdkName(SentryEnvironment.SDK_NAME + ":jul")
+            .withSdkIntegration("java.util.logging")
             .withLevel(getLevel(record.getLevel()))
             .withTimestamp(new Date(record.getMillis()))
             .withLogger(record.getLoggerName());

--- a/sentry/src/main/java/io/sentry/marshaller/json/JsonMarshaller.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/JsonMarshaller.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.Event;
+import io.sentry.event.Sdk;
 import io.sentry.event.interfaces.SentryInterface;
 import io.sentry.marshaller.Marshaller;
 import io.sentry.util.Util;
@@ -188,7 +189,7 @@ public class JsonMarshaller implements Marshaller {
         generator.writeStringField(LOGGER, event.getLogger());
         generator.writeStringField(PLATFORM, event.getPlatform());
         generator.writeStringField(CULPRIT, event.getCulprit());
-        writeSdk(generator, event.getSdkName(), event.getSdkVersion());
+        writeSdk(generator, event.getSdk());
         writeTags(generator, event.getTags());
         writeBreadcumbs(generator, event.getBreadcrumbs());
         writeContexts(generator, event.getContexts());
@@ -280,10 +281,17 @@ public class JsonMarshaller implements Marshaller {
         }
     }
 
-    private void writeSdk(JsonGenerator generator, String sdkName, String sdkVersion) throws IOException {
+    private void writeSdk(JsonGenerator generator, Sdk sdk) throws IOException {
         generator.writeObjectFieldStart(SDK);
-        generator.writeStringField("name", sdkName);
-        generator.writeStringField("version", sdkVersion);
+        generator.writeStringField("name", sdk.getName());
+        generator.writeStringField("version", sdk.getVersion());
+        if (sdk.getIntegrations() != null && !sdk.getIntegrations().isEmpty()) {
+            generator.writeArrayFieldStart("integrations");
+            for (String integration : sdk.getIntegrations()) {
+                generator.writeString(integration);
+            }
+            generator.writeEndArray();
+        }
         generator.writeEndObject();
     }
 

--- a/sentry/src/test/java/io/sentry/jul/SentryHandlerEventBuildingTest.java
+++ b/sentry/src/test/java/io/sentry/jul/SentryHandlerEventBuildingTest.java
@@ -54,6 +54,8 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
 
         sentryHandler.publish(newLogRecord(loggerName, Level.INFO, message, arguments, null, null, threadId, date.getTime()));
 
+
+
         new Verifications() {{
             EventBuilder eventBuilder;
             mockSentryClient.sendEvent(eventBuilder = withCapture());
@@ -66,7 +68,9 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
             assertThat(event.getLogger(), is(loggerName));
             assertThat(event.getExtra(), Matchers.<String, Object>hasEntry(SentryHandler.THREAD_ID, (int) threadId));
             assertThat(event.getTimestamp(), is(date));
-            assertThat(event.getSdkName(), is(SentryEnvironment.SDK_NAME + ":jul"));
+            event.getSdk();
+            event.getSdk().getIntegrations();
+            assertThat(event.getSdk().getIntegrations(), contains("java.util.logging"));
         }};
         assertNoErrorsInErrorManager();
     }

--- a/sentry/src/test/java/io/sentry/marshaller/json/JsonMarshallerTest.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/JsonMarshallerTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sentry.BaseTest;
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.BreadcrumbBuilder;
+import io.sentry.event.Sdk;
 import mockit.*;
 import io.sentry.event.Event;
 import io.sentry.event.interfaces.SentryInterface;
@@ -143,14 +144,15 @@ public class JsonMarshallerTest extends BaseTest {
     }
 
     @Test
-    public void testEventPlaftormWrittenProperly(@Injectable("sdkName") final String mockSdkName,
-                                                 @Injectable("sdkVersion") final String mockSdkVersion) throws Exception {
+    public void testEventSdkWrittenProperly() throws Exception {
+        HashSet<String> integrations = new HashSet<>();
+        integrations.add("integration1");
+        integrations.add("integration2");
+        final Sdk sdk = new Sdk("sdkName", "sdkVersion", integrations);
         final JsonOutputStreamParser jsonOutputStreamParser = newJsonOutputStream();
         new NonStrictExpectations() {{
-            mockEvent.getSdkName();
-            result = mockSdkName;
-            mockEvent.getSdkVersion();
-            result = mockSdkVersion;
+            mockEvent.getSdk();
+            result = sdk;
         }};
 
         jsonMarshaller.marshall(mockEvent, jsonOutputStreamParser.outputStream());

--- a/sentry/src/test/java/io/sentry/unmarshaller/event/UnmarshalledEvent.java
+++ b/sentry/src/test/java/io/sentry/unmarshaller/event/UnmarshalledEvent.java
@@ -26,7 +26,7 @@ public class UnmarshalledEvent {
     @JsonProperty(value = "platform")
     private String platform;
     @JsonProperty(value = "sdk")
-    private Map<String, String> sdk;
+    private Map<String, Object> sdk;
     @JsonProperty(value = "culprit")
     private String culprit;
     @JsonProperty(value = "tags")

--- a/sentry/src/test/resources/io/sentry/marshaller/json/jsonmarshallertest/testSdk.json
+++ b/sentry/src/test/resources/io/sentry/marshaller/json/jsonmarshallertest/testSdk.json
@@ -15,6 +15,7 @@
   "checksum": null,
   "sdk": {
     "name": "sdkName",
-    "version": "sdkVersion"
+    "version": "sdkVersion",
+    "integrations": ["integration2", "integration1"]
   }
 }


### PR DESCRIPTION
`integrations` is currently stripped (I guess?) since it's not a part of the Sentry server.

Sentry PR: https://github.com/getsentry/raven-python/pull/1011